### PR TITLE
fix: tolerate InsertLeave without preceding InsertEnter (#4)

### DIFF
--- a/lua/tirenvi/autocmd.lua
+++ b/lua/tirenvi/autocmd.lua
@@ -209,7 +209,10 @@ local function register_autocmds()
 				return
 			end
 			log.debug("===+===+===+===+=== %s %s ===+===+===+===+===", args.event, args.buf)
-			assert(vim.b[args.buf][CONST.BUF_KEY.INSERT_MODE])
+			-- InsertLeave may be triggered without a preceding InsertEnter
+			-- due to the behavior of other plugins (e.g., Telescope).
+			-- Do not assert INSERT_MODE here.
+			-- assert(vim.b[args.buf][CONST.BUF_KEY.INSERT_MODE])
 			vim.b[args.buf][CONST.BUF_KEY.INSERT_MODE] = false
 			if vim.b[args.buf][CONST.BUF_KEY.PENDING_REPAIR_ROWS] then
 				validity.repair_invalid_tir_vim(args.buf, 0, -1, -1, true)


### PR DESCRIPTION
## Description

### Summary

This PR removes an invalid assumption in the `InsertLeave` handler.

`InsertLeave` may be triggered without a preceding `InsertEnter` due to the behavior of external plugins (e.g., Telescope). The previous implementation asserted that `INSERT_MODE` must always be set, which caused an assertion failure in this scenario.

The assertion has been removed, and the handler now safely continues execution.

---

### Root cause

Neovim does not guarantee strict symmetry between `InsertEnter` and `InsertLeave` events.
When switching buffers via Telescope’s buffer picker, `InsertLeave` may be emitted even if `InsertEnter` was not previously triggered for the buffer.

---

### Changes

* Removed assertion in `InsertLeave`
* Kept post-processing logic (resetting `INSERT_MODE` and running pending repairs)

---

### Safety

The change only relaxes an incorrect event symmetry assumption.
The remaining logic is idempotent and safe to execute even when `INSERT_MODE` was not previously set.

Fixes #4
