### PR TITLE
fix: prevent undo tree from being cleared on :e! reload

### DIFF
--- a/lua/tirenvi/autocmd.lua
+++ b/lua/tirenvi/autocmd.lua
@@ -2,7 +2,7 @@
 local CONST = require("tirenvi.constants")
 local guard = require("tirenvi.guard")
 local config = require("tirenvi.config")
-local api = require("tirenvi")
+local api = require("tirenvi.init")
 local buf_state = require("tirenvi.buf_state")
 local vimHelper = require("tirenvi.vimHelper")
 local log = require("tirenvi.log")
@@ -33,7 +33,7 @@ end
 
 ---@param args table
 local function on_buf_read_post(args)
-	api.import_flat(args.buf, false)
+	api.import_flat(args.buf)
 	attach_on_lines(args.buf)
 end
 

--- a/lua/tirenvi/constants.lua
+++ b/lua/tirenvi/constants.lua
@@ -8,6 +8,9 @@ M.NG_LINE_MARK = "TIRVIM-NG" .. config.marks.pipe
 -- Buffer-local flags.
 local PREFIX = "tirenvi_"
 M.BUF_KEY = {
+	-- Set only when バッファが最初に表示された
+	INITIALIZED = PREFIX .. "initialized",
+
 	-- Set only when the on_lines callback is attached.
 	ATTACH_COUNT = PREFIX .. "attached",
 

--- a/lua/tirenvi/init.lua
+++ b/lua/tirenvi/init.lua
@@ -22,9 +22,9 @@ M.motion = require("tirenvi.motion")
 ---@param opts {[string]: any}
 ---@return string[] | nil
 local function run(func, bufnr, opts)
-	local ul
-	if opts.undo == false then
-		ul = vim.bo[bufnr].undolevels
+	local undolevels
+	if not vim.b[bufnr][CONST.BUF_KEY.INITIALIZED] then
+		undolevels = vim.bo[bufnr].undolevels
 		vim.bo[bufnr].undolevels = -1
 	end
 
@@ -36,8 +36,9 @@ local function run(func, bufnr, opts)
 		log.debug("===[api call]after=== [1] %s, [%d] %s", new_lines[1], #new_lines, new_lines[#new_lines])
 		vimHelper.set_lines(bufnr, 0, -1, false, new_lines)
 	end
-	if opts.undo == false then
-		vim.bo[bufnr].undolevels = ul
+	if not vim.b[bufnr][CONST.BUF_KEY.INITIALIZED] then
+		vim.b[bufnr][CONST.BUF_KEY.INITIALIZED] = true
+		vim.bo[bufnr].undolevels = undolevels
 	end
 	return new_lines
 end
@@ -63,18 +64,13 @@ local function to_flat(bufnr, old_path, new_path)
 end
 
 ---@param bufnr number Buffer number.
----@param undo_mode boolean|nil
 ---@param new_path string|nil
 ---@param old_path string|nil
 ---@return nil
-local function from_flat(bufnr, undo_mode, new_path, old_path)
-	if undo_mode == nil then
-		undo_mode = true
-	end
+local function from_flat(bufnr, new_path, old_path)
 	local parser = vimHelper.get_parser_name(bufnr, new_path, old_path)
 	local opts = {
 		parser = parser,
-		undo = undo_mode,
 	}
 	run(tir_vim.from_flat, bufnr, opts)
 end
@@ -99,10 +95,10 @@ end
 
 --- Convert current buffer (or specified buffer) from plain format to tir-vim format
 ---@param bufnr number Buffer number.
----@param undo_mode boolean
 ---@return nil
-function M.import_flat(bufnr, undo_mode)
-	from_flat(bufnr, undo_mode)
+function M.import_flat(bufnr)
+	pcall(vim.cmd, "undojoin")
+	from_flat(bufnr)
 end
 
 ---@param bufnr number Buffer number.
@@ -145,7 +141,7 @@ end
 ---@return nil
 function M.restore_tir_vim(bufnr, new_path, old_path)
 	pcall(vim.cmd, "undojoin")
-	from_flat(bufnr, true, new_path, old_path)
+	from_flat(bufnr, new_path, old_path)
 end
 
 ---@param bufnr number Buffer number.


### PR DESCRIPTION
## Summary

Fix an issue where the undo tree was cleared after `:e!`
when tirenvi was enabled.

## Details

tirenvi rewrites the buffer in `BufReadPost` to transform
flat representation into tir-vim representation.

Previously, this transformation always modified 'undolevels'
to prevent the change from being undoable.

However, this also affected reload scenarios (`:e!`),
causing the undo tree to be reset.

This PR limits the workaround to the initial load only,
preserving normal Neovim behavior on reload.

Fixes #6