### PR TITLE
refactor: clarify JSON error handling policy

### DIFF
--- a/lua/tirenvi/errors.lua
+++ b/lua/tirenvi/errors.lua
@@ -97,4 +97,11 @@ function M.not_found_parser_error(parser)
 	)
 end
 
+---@param js_line string
+---@param message string
+---@return string
+function M.invalid_json_error(js_line, message)
+	return string.format(PREFIX .. "tirenvi: invalid JSON from parser\n%s\nerror: %s", js_line, message)
+end
+
 return M

--- a/lua/tirenvi/parser.lua
+++ b/lua/tirenvi/parser.lua
@@ -75,7 +75,10 @@ local function js_lines_to_records(js_lines)
 	local js_records = {}
 	for _, js_line in ipairs(js_lines) do
 		if js_line ~= nil and js_line ~= "" then
-			local js_record = vim.json.decode(js_line)
+			local ok, js_record = pcall(vim.json.decode, js_line)
+			if not ok then
+				error(errors.new_domain_error(errors.invalid_json_error(js_line, js_record)))
+			end
 			table.insert(js_records, js_record)
 		end
 	end
@@ -89,11 +92,8 @@ local function js_records_to_lines(records)
 	for _, record in ipairs(records) do
 		if record ~= nil then
 			local ok, encoded = pcall(vim.json.encode, record)
-			if ok then
-				table.insert(lines, encoded)
-			else
-				assert(false, ("tirenvi: failed to encode record\n%s\nerror: %s"):format(vim.inspect(record), encoded))
-			end
+			assert(ok, ("tirenvi: internal JSON encode failure\n%s\nerror: %s"):format(vim.inspect(record), encoded))
+			table.insert(lines, encoded)
 		end
 	end
 	return lines


### PR DESCRIPTION
## Summary

Clarify JSON encode/decode error handling policy.

## Details

- JSON encoding is used only for internally constructed records.
  Encoding failure indicates an internal invariant violation,
  so it is explicitly asserted.

- JSON decoding consumes output from an external parser.
  Since this input cannot be fully trusted, decoding is wrapped
  with `pcall` to prevent unexpected crashes.

This change does not alter external behavior.
It makes the intended error-handling strategy explicit in code.