### PR TITLE
docs: add command flow documentation for tirenvi pipeline

### DIFF
--- a/docs/command-flow.md
+++ b/docs/command-flow.md
@@ -1,0 +1,87 @@
+# Command Flow
+
+Blocks represent the logical TIR structure,
+while Records represent the rendered Vim table representation.
+
+## Data Types
+
+```text
+flat file
+   ↓
+fl_lines   : string[]   (flat text lines)
+   ↓
+js_lines   : string[]   (NDJSON text lines)
+   ↓
+ndjsons    : Ndjson[]   (parsed NDJSON objects: Attr_file | Attr | Record)
+   ↓
+Blocks     : Block[]    (TIR block structure)
+   ↓
+records    : Record[]   (unparsed Record objects)
+   ↓
+vi_lines   : string[]   (lines rendered for vim buffer)
+   ↓
+vim buffer
+```
+
+---
+
+## BufReadPost (init.lua from_flat)
+
+```text
+flat file
+  → (neovim)            read file into fl_lines
+  → (external parser)   fl_lines → js_lines
+  → (flat_parser.lua)   js_lines → ndjsons → Blocks (escape lf, tab)
+  → (vim_parser.lua)    Blocks → records (add padding into cell) → vi_lines
+  → (neovim)            replace vim buffer
+```
+
+---
+
+## BufWritePre (init.lua to_flat)
+
+```text
+vim buffer
+  → (neovim)            get lines into vi_lines
+  → (vim_parser.lua)    vi_lines → records → Blocks (remove padding from cell)
+  → (flat_parser.lua)   Blocks → ndjsons (unescape lf, tab) → js_lines
+  → (external parser)   js_lines → fl_lines
+  → (neovim)            write to file
+```
+
+## BufWritePost
+
+init.lua from_flat
+
+## BufFilePost
+
+init.lua to_flat
+
+## :Tir redraw
+
+```text
+vim buffer
+  → (neovim)            get lines into vi_lines
+  → (vim_parser.lua)    vi_lines → records →  Blocks (remove padding from cell)
+  → (vim_parser.lua)    Blocks → records (add padding in cell) → vi_lines
+  → (neovim)            replace vim buffer
+```
+
+## :Tir toggle (disable)
+
+init.lua to_flat
+
+## :Tir toggle (enable)
+
+init.lua from_flat
+
+## on_lines
+
+```text
+vim buffer
+  → (neovim)            get lines into vi_lines
+  → (vim_parser.lua)    vi_lines → Records →  Blocks (remove padding from cell)
+  → (validator.lua)     Blocks.validate()
+  → (vim_parser.lua)    Blocks → Records (add padding in cell) → vi_lines
+  → (neovim)            replace vim buffer
+```

--- a/lua/tirenvi/core/blocks.lua
+++ b/lua/tirenvi/core/blocks.lua
@@ -246,7 +246,7 @@ end
 ---@param allow_plain boolean | nil
 ---@return boolean
 ---@return RefAttrError | nil
-function M:set_reference_attr(attr_prev, attr_next, allow_plain)
+function M:validate(attr_prev, attr_next, allow_plain)
 	if allow_plain then
 		apply_reference_attr_multi(self, attr_prev, attr_next)
 		return true

--- a/lua/tirenvi/core/validator.lua
+++ b/lua/tirenvi/core/validator.lua
@@ -58,7 +58,7 @@ local function get_repaired_lines(bufnr, start_row, end_row)
 	local attr_prev, attr_next = get_reference_attrs(bufnr, start_row, end_row)
 	local parser = util.get_parser(bufnr)
 	local allow_plain = parser.allow_plain
-	local success, reason = Blocks.set_reference_attr(blocks, attr_prev, attr_next, allow_plain)
+	local success, reason = Blocks.validate(blocks, attr_prev, attr_next, allow_plain)
 	if not success then
 		if reason == "grid in plain" then
 			return flat_parser.unparse(blocks, parser)

--- a/lua/tirenvi/init.lua
+++ b/lua/tirenvi/init.lua
@@ -45,8 +45,8 @@ local function from_flat(bufnr, new_path, old_path)
 	util.assert_no_reserved_marks(fl_lines)
 	local parser = util.get_parser(bufnr, new_path, old_path)
 	local blocks = flat_parser.parse(fl_lines, parser)
-	local new_lines = vim_parser.unparse(blocks)
-	buffer.set_lines(bufnr, 0, -1, new_lines)
+	local vi_lines = vim_parser.unparse(blocks)
+	buffer.set_lines(bufnr, 0, -1, vi_lines)
 end
 
 -- public API


### PR DESCRIPTION
This PR adds a developer document describing the internal
command flow of tirenvi.

The document explains the data transformation pipeline used
by tirenvi, including:

- BufReadPost initialization
- BufWritePre write pipeline
- redraw command
- toggle command
- on_lines validation

It also introduces the main internal data structures:
fl_lines, js_lines, ndjsons, Blocks, Records, and vi_lines.
