### PR TITLE
refactor: remove "default" from Align

### DIFF
--- a/lua/tirenvi/constants.lua
+++ b/lua/tirenvi/constants.lua
@@ -9,7 +9,6 @@ M.KIND = {
 	GRID = "grid",
 }
 M.ALIGN = {
-	DEFAULT = "default",
 	LEFT = "left",
 	CENTER = "center",
 	RIGHT = "right",

--- a/lua/tirenvi/core/attr.lua
+++ b/lua/tirenvi/core/attr.lua
@@ -17,7 +17,7 @@ local function get_columns(cells)
     local columns = {}
     local widths = Cell.get_widths(cells)
     for _, width in ipairs(widths) do
-        columns[#columns + 1] = { align = CONST.ALIGN.DEFAULT, width = width }
+        columns[#columns + 1] = { align = CONST.ALIGN.LEFT, width = width }
     end
     return columns
 end
@@ -38,7 +38,7 @@ local function merge(self, source)
         elseif scol then
             mcol.width = math.max(mcol.width, scol.width)
             if mcol.align ~= scol.align then
-                mcol.align = CONST.ALIGN.DEFAULT
+                mcol.align = CONST.ALIGN.LEFT
             end
         end
     end

--- a/lua/tirenvi/types.lua
+++ b/lua/tirenvi/types.lua
@@ -39,7 +39,7 @@
 ---@field width? integer  -- display width (logical column width)
 ---@field align? Align
 
----@alias Align "left" | "center" | "right" | "default"
+---@alias Align "left" | "center" | "right"
 
 ---@alias Record Record_plain | Record_grid
 


### PR DESCRIPTION
Remove "default" from Align.

The "default" alignment cannot be preserved when converting
TIR -> tir-vim. As a result, alignment information may be lost.

To avoid this ambiguity, the "default" value is removed from
Align and only explicit values are allowed:

  "left" | "center" | "right"

This makes the conversion behavior explicit and prevents
information loss between formats.