### PR TITLE
docs: use full PR references (owner/repo#number) in test specifications

### DIFF
--- a/docs/testing/tir-toggle.md
+++ b/docs/testing/tir-toggle.md
@@ -13,7 +13,7 @@
 ## implement
 
 * branch name: feat/persist-column-width-on-toggle
-* PR: #53
+* PR: kibi2/tirenvi.nvim#53
 
 | No | Preconditions | Action | Expected | Date | Notes | Commit Message |
 | --- | --- | --- | --- | --- | --- | --- |


### PR DESCRIPTION
## Summary

Update test specifications to use full PR references (`owner/repo#number`) instead of short `#number` format.

---

## Motivation

Short PR references (e.g. `#53`) are not consistently rendered as links in Markdown files within the repository.
Using full references ensures that links are always resolved correctly, regardless of context.

---

## Changes

* Replace short PR references with full format:

  * `#53` → `owner/repo#53`

---

## Notes

* This improves traceability from test specifications to PRs
* The change is documentation-only and does not affect runtime behavior
