### PR TITLE
fix: empty notify and buffer local autocmds

### DIFF
--- a/lua/tirenvi/editor/autocmd.lua
+++ b/lua/tirenvi/editor/autocmd.lua
@@ -93,26 +93,23 @@ local function debug_entry_point(args)
 	log.debug("===+===+===+===+=== %s(%d)%s ===+===+===+===+===", args.event, args.buf, filetype)
 end
 
-local function register_autocmds()
-	local augroup = api.nvim_create_augroup(GROUP_NAME, { clear = true })
-	api.nvim_create_autocmd("BufReadPost", {
-		group = augroup,
-		-- Process only items for which a parser has been specified
-		callback = guard.guarded(function(args)
-			if buf_state.should_skip(args.buf, {
-					supported = true,
-					no_vscode = true,
-					has_parser = true,
-				}) then
-				return
-			end
-			debug_entry_point(args)
-			on_buf_read_post(args)
-		end),
-	})
+---@param filetype string|nil
+---@return boolean
+local function is_configured_filetype(filetype)
+	return filetype ~= nil and filetype ~= "" and config.parser_map[filetype] ~= nil
+end
+
+---@param augroup integer
+---@param bufnr number
+local function register_buffer_local_autocmds(augroup, bufnr)
+	if vim.b[bufnr].tirenvi_autocmds_registered then
+		return
+	end
+	vim.b[bufnr].tirenvi_autocmds_registered = true
 
 	api.nvim_create_autocmd("BufWritePre", {
 		group = augroup,
+		buffer = bufnr,
 		callback = guard.guarded(function(args)
 			if buf_state.should_skip(args.buf, {
 					supported = true,
@@ -127,6 +124,7 @@ local function register_autocmds()
 
 	api.nvim_create_autocmd("BufWritePost", {
 		group = augroup,
+		buffer = bufnr,
 		callback = guard.guarded(function(args)
 			if buf_state.should_skip(args.buf, {
 					supported = true,
@@ -140,6 +138,7 @@ local function register_autocmds()
 
 	api.nvim_create_autocmd("CursorHold", {
 		group = augroup,
+		buffer = bufnr,
 		callback = guard.guarded(function(args)
 			if buf_state.should_skip(args.buf, {
 					supported = true,
@@ -147,15 +146,14 @@ local function register_autocmds()
 				}) then
 				return
 			end
-			-- debug_entry_point(args)
 			on_cursor_hold(args)
 		end),
 	})
 
 	api.nvim_create_autocmd("InsertEnter", {
 		group = augroup,
+		buffer = bufnr,
 		callback = guard.guarded(function(args)
-			debug_entry_point(args)
 			if buf_state.should_skip(args.buf, {
 					supported = true,
 					has_parser = true,
@@ -170,6 +168,7 @@ local function register_autocmds()
 
 	api.nvim_create_autocmd("InsertLeave", {
 		group = augroup,
+		buffer = bufnr,
 		callback = guard.guarded(function(args)
 			if buf_state.should_skip(args.buf, {
 					supported = true,
@@ -188,6 +187,7 @@ local function register_autocmds()
 
 	api.nvim_create_autocmd("InsertCharPre", {
 		group = augroup,
+		buffer = bufnr,
 		callback = guard.guarded(function(args)
 			if buf_state.should_skip(args.buf, {
 					supported = true,
@@ -201,6 +201,8 @@ local function register_autocmds()
 	})
 
 	vim.api.nvim_create_autocmd({ "BufWinEnter", "WinEnter" }, {
+		group = augroup,
+		buffer = bufnr,
 		callback = guard.guarded(function(args)
 			if buf_state.should_skip(args.buf, {
 					supported = true,
@@ -212,8 +214,12 @@ local function register_autocmds()
 			ui.special_apply()
 		end),
 	})
+end
 
+local function register_autocmds()
+	local augroup = api.nvim_create_augroup(GROUP_NAME, { clear = true })
 	vim.api.nvim_create_autocmd("WinClosed", {
+		group = augroup,
 		callback = guard.guarded(function(args)
 			local winid = tonumber(args.match)
 			pcall(ui.clear_matches, winid)
@@ -221,9 +227,31 @@ local function register_autocmds()
 	})
 
 	vim.api.nvim_create_autocmd("FileType", {
+		group = augroup,
 		callback = guard.guarded(function(args)
+			local now_supported = is_configured_filetype(bo[args.buf].filetype)
+			local was_registered = vim.b[args.buf].tirenvi_autocmds_registered == true
+			local active = was_registered or buf_state.is_tir_vim(args.buf)
+
+			if not now_supported and not active then
+				return
+			end
+
 			debug_entry_point(args)
 			on_filetype(args)
+
+			if not now_supported then
+				if vim.b[args.buf].tirenvi_autocmds_registered then
+					api.nvim_clear_autocmds({ group = augroup, buffer = args.buf })
+					vim.b[args.buf].tirenvi_autocmds_registered = nil
+				end
+				return
+			end
+
+			register_buffer_local_autocmds(augroup, args.buf)
+			if not was_registered then
+				on_buf_read_post(args)
+			end
 		end),
 	})
 

--- a/lua/tirenvi/editor/autocmd.lua
+++ b/lua/tirenvi/editor/autocmd.lua
@@ -107,14 +107,32 @@ local function register_buffer_local_autocmds(augroup, bufnr)
 	end
 	vim.b[bufnr].tirenvi_autocmds_registered = true
 
+	api.nvim_create_autocmd("BufReadPost", {
+		group = augroup,
+		buffer = bufnr,
+		callback = guard.guarded(function(args)
+			if
+				buf_state.should_skip(args.buf, {
+					supported = true,
+					no_vscode = true,
+					has_parser = true,
+				})
+			then
+				return
+			end
+			debug_entry_point(args)
+			on_buf_read_post(args)
+		end),
+	})
+
 	api.nvim_create_autocmd("BufWritePre", {
 		group = augroup,
 		buffer = bufnr,
 		callback = guard.guarded(function(args)
 			if buf_state.should_skip(args.buf, {
-					supported = true,
-					is_tir_vim = true,
-				}) then
+				supported = true,
+				is_tir_vim = true,
+			}) then
 				return
 			end
 			debug_entry_point(args)
@@ -127,8 +145,8 @@ local function register_buffer_local_autocmds(augroup, bufnr)
 		buffer = bufnr,
 		callback = guard.guarded(function(args)
 			if buf_state.should_skip(args.buf, {
-					supported = true,
-				}) then
+				supported = true,
+			}) then
 				return
 			end
 			debug_entry_point(args)
@@ -141,9 +159,9 @@ local function register_buffer_local_autocmds(augroup, bufnr)
 		buffer = bufnr,
 		callback = guard.guarded(function(args)
 			if buf_state.should_skip(args.buf, {
-					supported = true,
-					has_parser = true,
-				}) then
+				supported = true,
+				has_parser = true,
+			}) then
 				return
 			end
 			on_cursor_hold(args)
@@ -155,9 +173,9 @@ local function register_buffer_local_autocmds(augroup, bufnr)
 		buffer = bufnr,
 		callback = guard.guarded(function(args)
 			if buf_state.should_skip(args.buf, {
-					supported = true,
-					has_parser = true,
-				}) then
+				supported = true,
+				has_parser = true,
+			}) then
 				return
 			end
 			debug_entry_point(args)
@@ -171,9 +189,9 @@ local function register_buffer_local_autocmds(augroup, bufnr)
 		buffer = bufnr,
 		callback = guard.guarded(function(args)
 			if buf_state.should_skip(args.buf, {
-					supported = true,
-					has_parser = true,
-				}) then
+				supported = true,
+				has_parser = true,
+			}) then
 				return
 			end
 			debug_entry_point(args)
@@ -190,9 +208,9 @@ local function register_buffer_local_autocmds(augroup, bufnr)
 		buffer = bufnr,
 		callback = guard.guarded(function(args)
 			if buf_state.should_skip(args.buf, {
-					supported = true,
-					is_tir_vim = true,
-				}) then
+				supported = true,
+				is_tir_vim = true,
+			}) then
 				return
 			end
 			debug_entry_point(args)
@@ -205,9 +223,9 @@ local function register_buffer_local_autocmds(augroup, bufnr)
 		buffer = bufnr,
 		callback = guard.guarded(function(args)
 			if buf_state.should_skip(args.buf, {
-					supported = true,
-					is_tir_vim = true,
-				}) then
+				supported = true,
+				is_tir_vim = true,
+			}) then
 				return
 			end
 			ui.special_clear()

--- a/lua/tirenvi/state/buf_state.lua
+++ b/lua/tirenvi/state/buf_state.lua
@@ -1,6 +1,6 @@
 local log = require("tirenvi.util.log")
 local errors = require("tirenvi.util.errors")
-local util = require("tirenvi.util.util")
+local config = require("tirenvi.config")
 local buffer = require("tirenvi.state.buffer")
 local tir_vim = require("tirenvi.core.tir_vim")
 
@@ -16,9 +16,20 @@ local function ensure_has_parser(bufnr)
 		log.debug("buftype:%s", bo[bufnr].buftype)
 		return false
 	end
-	local parser = util.get_parser(bufnr)
-	assert(parser ~= nil, "If no parser exists, an error is raised inside get_parser_name.")
-	return true
+
+	local filetype = buffer.get(bufnr, buffer.IKEY.FILETYPE)
+	if not filetype then
+		return false
+	end
+
+	local parser = config.parser_map[filetype]
+	if not parser then
+		return false
+	end
+
+	-- For passive checks (autocmd gating), missing executables should only
+	-- skip processing rather than raise user-facing notifications.
+	return fn.executable(parser.executable) == 1
 end
 
 --- has pipe markers. for example, it may be a tir-vim buffer.

--- a/lua/tirenvi/util/util.lua
+++ b/lua/tirenvi/util/util.lua
@@ -120,7 +120,8 @@ function M.get_parser(bufnr)
 	bufnr = bufnr or vim.api.nvim_get_current_buf()
 	local parser = get_parser_for_file(bufnr)
 	if parser == nil then
-		error(errors.new_domain_error(""))
+		local filetype = buffer.get(bufnr, buffer.IKEY.FILETYPE)
+		error(errors.new_domain_error(errors.no_parser_error(filetype)))
 	end
 	if fn.executable(parser.executable) ~= 1 then
 		error(errors.new_domain_error(errors.not_found_parser_error(parser)))


### PR DESCRIPTION
## Summary

This PR addresses two issues:

1. Empty error notifications from parser checks.
2. Unnecessary global autocmd callback overhead in unrelated buffers.

## Changes

### 1) Fix empty parser error notifications

Files:
- `lua/tirenvi/state/buf_state.lua`
- `lua/tirenvi/util/util.lua`

What changed:
- `ensure_has_parser()` no longer calls `util.get_parser()` in passive skip-check paths.
- It now checks parser mapping/executable directly and returns `false` when unsupported/missing.
- `get_parser()` now emits explicit `no_parser_error(filetype)` instead of an empty domain error string.

Result:
- No more blank notifications from skip-check/autocmd flows.
- Active parser failures remain user-visible and actionable.

### 2) Scope high-frequency autocmds to supported buffers

File:
- `lua/tirenvi/editor/autocmd.lua`

What changed:
- Switched to buffer-local registration for high-frequency events:
- `BufWritePre`, `BufWritePost`
- `CursorHold`
- `InsertEnter`, `InsertLeave`, `InsertCharPre`
- `BufWinEnter`, `WinEnter`
- Global autocmds are now used only for orchestration (`FileType`, `WinClosed`, `VimLeave`).
- On `FileType`, handlers are attached only for supported filetypes (or active tir-vim state), and detached when no longer needed.

Result:
- Unrelated buffers no longer pay callback overhead for tirenvi runtime events.
- Behavior for supported buffers is preserved.

## Why

The plugin previously relied on global callbacks plus early returns.

That works functionally but still executes callback functions broadly and can surface noisy UX (including empty notifications in some paths).

This PR keeps behavior while making event routing tighter and less noisy.
