### PR TITLE
fix: correct LICENSE to be recognized as MIT

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
-Copyrigh (c) 2026 OGAWA Keiji
+Copyright (c) 2026 OGAWA Keiji
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 


### PR DESCRIPTION
Fix LICENSE so GitHub correctly detects it as MIT.

The previous file had:
- a typo in "Copyright"
- smart quotes (“ ”) instead of ASCII quotes (")

These prevented GitHub from recognizing the license.

This change aligns the file with the standard MIT template.