### PR TITLE
fix: empty notification and buffer-local autocmds

### DIFF
--- a/lua/tirenvi/editor/autocmd.lua
+++ b/lua/tirenvi/editor/autocmd.lua
@@ -95,26 +95,23 @@ local function debug_entry_point(args)
 	log.debug("===+===+===+===+=== %s(%d)%s ===+===+===+===+===", args.event, args.buf, filetype)
 end
 
-local function register_autocmds()
-	local augroup = api.nvim_create_augroup(GROUP_NAME, { clear = true })
-	api.nvim_create_autocmd("BufReadPost", {
-		group = augroup,
-		-- Process only items for which a parser has been specified
-		callback = guard.guarded(function(args)
-			if buf_state.should_skip(args.buf, {
-					supported = true,
-					no_vscode = true,
-					has_parser = true,
-				}) then
-				return
-			end
-			debug_entry_point(args)
-			on_buf_read_post(args)
-		end),
-	})
+---@param filetype string|nil
+---@return boolean
+local function is_configured_filetype(filetype)
+	return filetype ~= nil and filetype ~= "" and config.parser_map[filetype] ~= nil
+end
+
+---@param augroup integer
+---@param bufnr number
+local function register_buffer_local_autocmds(augroup, bufnr)
+	if vim.b[bufnr].tirenvi_autocmds_registered then
+		return
+	end
+	vim.b[bufnr].tirenvi_autocmds_registered = true
 
 	api.nvim_create_autocmd("BufWritePre", {
 		group = augroup,
+		buffer = bufnr,
 		callback = guard.guarded(function(args)
 			if buf_state.should_skip(args.buf, {
 					supported = true,
@@ -129,6 +126,7 @@ local function register_autocmds()
 
 	api.nvim_create_autocmd("BufWritePost", {
 		group = augroup,
+		buffer = bufnr,
 		callback = guard.guarded(function(args)
 			if buf_state.should_skip(args.buf, {
 					supported = true,
@@ -142,6 +140,7 @@ local function register_autocmds()
 
 	api.nvim_create_autocmd("CursorHold", {
 		group = augroup,
+		buffer = bufnr,
 		callback = guard.guarded(function(args)
 			if buf_state.should_skip(args.buf, {
 					supported = true,
@@ -149,15 +148,14 @@ local function register_autocmds()
 				}) then
 				return
 			end
-			-- debug_entry_point(args)
 			on_cursor_hold(args)
 		end),
 	})
 
 	api.nvim_create_autocmd("InsertEnter", {
 		group = augroup,
+		buffer = bufnr,
 		callback = guard.guarded(function(args)
-			debug_entry_point(args)
 			if buf_state.should_skip(args.buf, {
 					supported = true,
 					has_parser = true,
@@ -172,6 +170,7 @@ local function register_autocmds()
 
 	api.nvim_create_autocmd("InsertLeave", {
 		group = augroup,
+		buffer = bufnr,
 		callback = guard.guarded(function(args)
 			if buf_state.should_skip(args.buf, {
 					supported = true,
@@ -190,6 +189,7 @@ local function register_autocmds()
 
 	api.nvim_create_autocmd("InsertCharPre", {
 		group = augroup,
+		buffer = bufnr,
 		callback = guard.guarded(function(args)
 			if buf_state.should_skip(args.buf, {
 					supported = true,
@@ -203,6 +203,8 @@ local function register_autocmds()
 	})
 
 	vim.api.nvim_create_autocmd({ "BufWinEnter", "WinEnter" }, {
+		group = augroup,
+		buffer = bufnr,
 		callback = guard.guarded(function(args)
 			if buf_state.should_skip(args.buf, {
 					supported = true,
@@ -214,8 +216,12 @@ local function register_autocmds()
 			ui.special_apply()
 		end),
 	})
+end
 
+local function register_autocmds()
+	local augroup = api.nvim_create_augroup(GROUP_NAME, { clear = true })
 	vim.api.nvim_create_autocmd("WinClosed", {
+		group = augroup,
 		callback = guard.guarded(function(args)
 			local winid = tonumber(args.match)
 			pcall(ui.clear_matches, winid)
@@ -223,9 +229,31 @@ local function register_autocmds()
 	})
 
 	vim.api.nvim_create_autocmd("FileType", {
+		group = augroup,
 		callback = guard.guarded(function(args)
+			local now_supported = is_configured_filetype(bo[args.buf].filetype)
+			local was_registered = vim.b[args.buf].tirenvi_autocmds_registered == true
+			local active = was_registered or buf_state.is_tir_vim(args.buf)
+
+			if not now_supported and not active then
+				return
+			end
+
 			debug_entry_point(args)
 			on_filetype(args)
+
+			if not now_supported then
+				if vim.b[args.buf].tirenvi_autocmds_registered then
+					api.nvim_clear_autocmds({ group = augroup, buffer = args.buf })
+					vim.b[args.buf].tirenvi_autocmds_registered = nil
+				end
+				return
+			end
+
+			register_buffer_local_autocmds(augroup, args.buf)
+			if not was_registered then
+				on_buf_read_post(args)
+			end
 		end),
 	})
 

--- a/lua/tirenvi/editor/autocmd.lua
+++ b/lua/tirenvi/editor/autocmd.lua
@@ -109,14 +109,32 @@ local function register_buffer_local_autocmds(augroup, bufnr)
 	end
 	vim.b[bufnr].tirenvi_autocmds_registered = true
 
+	api.nvim_create_autocmd("BufReadPost", {
+		group = augroup,
+		buffer = bufnr,
+		callback = guard.guarded(function(args)
+			if
+				buf_state.should_skip(args.buf, {
+					supported = true,
+					no_vscode = true,
+					has_parser = true,
+				})
+			then
+				return
+			end
+			debug_entry_point(args)
+			on_buf_read_post(args)
+		end),
+	})
+
 	api.nvim_create_autocmd("BufWritePre", {
 		group = augroup,
 		buffer = bufnr,
 		callback = guard.guarded(function(args)
 			if buf_state.should_skip(args.buf, {
-					supported = true,
-					is_tir_vim = true,
-				}) then
+				supported = true,
+				is_tir_vim = true,
+			}) then
 				return
 			end
 			debug_entry_point(args)
@@ -129,8 +147,8 @@ local function register_buffer_local_autocmds(augroup, bufnr)
 		buffer = bufnr,
 		callback = guard.guarded(function(args)
 			if buf_state.should_skip(args.buf, {
-					supported = true,
-				}) then
+				supported = true,
+			}) then
 				return
 			end
 			debug_entry_point(args)
@@ -143,9 +161,9 @@ local function register_buffer_local_autocmds(augroup, bufnr)
 		buffer = bufnr,
 		callback = guard.guarded(function(args)
 			if buf_state.should_skip(args.buf, {
-					supported = true,
-					has_parser = true,
-				}) then
+				supported = true,
+				has_parser = true,
+			}) then
 				return
 			end
 			on_cursor_hold(args)
@@ -157,9 +175,9 @@ local function register_buffer_local_autocmds(augroup, bufnr)
 		buffer = bufnr,
 		callback = guard.guarded(function(args)
 			if buf_state.should_skip(args.buf, {
-					supported = true,
-					has_parser = true,
-				}) then
+				supported = true,
+				has_parser = true,
+			}) then
 				return
 			end
 			debug_entry_point(args)
@@ -173,9 +191,9 @@ local function register_buffer_local_autocmds(augroup, bufnr)
 		buffer = bufnr,
 		callback = guard.guarded(function(args)
 			if buf_state.should_skip(args.buf, {
-					supported = true,
-					has_parser = true,
-				}) then
+				supported = true,
+				has_parser = true,
+			}) then
 				return
 			end
 			debug_entry_point(args)
@@ -192,9 +210,9 @@ local function register_buffer_local_autocmds(augroup, bufnr)
 		buffer = bufnr,
 		callback = guard.guarded(function(args)
 			if buf_state.should_skip(args.buf, {
-					supported = true,
-					is_tir_vim = true,
-				}) then
+				supported = true,
+				is_tir_vim = true,
+			}) then
 				return
 			end
 			debug_entry_point(args)
@@ -207,9 +225,9 @@ local function register_buffer_local_autocmds(augroup, bufnr)
 		buffer = bufnr,
 		callback = guard.guarded(function(args)
 			if buf_state.should_skip(args.buf, {
-					supported = true,
-					is_tir_vim = true,
-				}) then
+				supported = true,
+				is_tir_vim = true,
+			}) then
 				return
 			end
 			ui.special_clear()

--- a/lua/tirenvi/editor/autocmd.lua
+++ b/lua/tirenvi/editor/autocmd.lua
@@ -3,8 +3,8 @@ local guard = require("tirenvi.util.guard")
 local buffer = require("tirenvi.state.buffer")
 local init = require("tirenvi.init")
 local buf_state = require("tirenvi.state.buf_state")
-local config = require("tirenvi.config")
 local log = require("tirenvi.util.log")
+local util = require("tirenvi.util.util")
 local ui = require("tirenvi.ui")
 
 -- module
@@ -30,6 +30,12 @@ local fn = vim.fn
 ---@param bytecount integer
 local function on_lines(_, bufnr, tick, first, last, new_last, bytecount)
 	buffer.clear_cache()
+	if buf_state.should_skip(bufnr, {
+			supported = true,
+			has_parser = true,
+		}) then
+		return
+	end
 	local seq_last = fn.undotree(bufnr).seq_last
 	log.debug("===+===+===+===+=== on_lines(%d)[%d](%d-%d) ===+===+===+===+===", bufnr, seq_last, first, new_last)
 	init.on_lines(bufnr, first, last, new_last)
@@ -95,46 +101,23 @@ local function debug_entry_point(args)
 	log.debug("===+===+===+===+=== %s(%d)%s ===+===+===+===+===", args.event, args.buf, filetype)
 end
 
----@param filetype string|nil
----@return boolean
-local function is_configured_filetype(filetype)
-	return filetype ~= nil and filetype ~= "" and config.parser_map[filetype] ~= nil
+---@param augroup integer
+---@param bufnr number
+local function clear_buffer_local_autocmds(augroup, bufnr)
+	api.nvim_clear_autocmds({ group = augroup, buffer = bufnr })
 end
 
 ---@param augroup integer
 ---@param bufnr number
 local function register_buffer_local_autocmds(augroup, bufnr)
-	if vim.b[bufnr].tirenvi_autocmds_registered then
-		return
-	end
-	vim.b[bufnr].tirenvi_autocmds_registered = true
-
-	api.nvim_create_autocmd("BufReadPost", {
-		group = augroup,
-		buffer = bufnr,
-		callback = guard.guarded(function(args)
-			if
-				buf_state.should_skip(args.buf, {
-					supported = true,
-					no_vscode = true,
-					has_parser = true,
-				})
-			then
-				return
-			end
-			debug_entry_point(args)
-			on_buf_read_post(args)
-		end),
-	})
-
 	api.nvim_create_autocmd("BufWritePre", {
 		group = augroup,
 		buffer = bufnr,
 		callback = guard.guarded(function(args)
 			if buf_state.should_skip(args.buf, {
-				supported = true,
-				is_tir_vim = true,
-			}) then
+					supported = true,
+					is_tir_vim = true,
+				}) then
 				return
 			end
 			debug_entry_point(args)
@@ -147,8 +130,8 @@ local function register_buffer_local_autocmds(augroup, bufnr)
 		buffer = bufnr,
 		callback = guard.guarded(function(args)
 			if buf_state.should_skip(args.buf, {
-				supported = true,
-			}) then
+					supported = true,
+				}) then
 				return
 			end
 			debug_entry_point(args)
@@ -161,9 +144,9 @@ local function register_buffer_local_autocmds(augroup, bufnr)
 		buffer = bufnr,
 		callback = guard.guarded(function(args)
 			if buf_state.should_skip(args.buf, {
-				supported = true,
-				has_parser = true,
-			}) then
+					supported = true,
+					has_parser = true,
+				}) then
 				return
 			end
 			on_cursor_hold(args)
@@ -175,9 +158,9 @@ local function register_buffer_local_autocmds(augroup, bufnr)
 		buffer = bufnr,
 		callback = guard.guarded(function(args)
 			if buf_state.should_skip(args.buf, {
-				supported = true,
-				has_parser = true,
-			}) then
+					supported = true,
+					has_parser = true,
+				}) then
 				return
 			end
 			debug_entry_point(args)
@@ -191,9 +174,9 @@ local function register_buffer_local_autocmds(augroup, bufnr)
 		buffer = bufnr,
 		callback = guard.guarded(function(args)
 			if buf_state.should_skip(args.buf, {
-				supported = true,
-				has_parser = true,
-			}) then
+					supported = true,
+					has_parser = true,
+				}) then
 				return
 			end
 			debug_entry_point(args)
@@ -210,9 +193,9 @@ local function register_buffer_local_autocmds(augroup, bufnr)
 		buffer = bufnr,
 		callback = guard.guarded(function(args)
 			if buf_state.should_skip(args.buf, {
-				supported = true,
-				is_tir_vim = true,
-			}) then
+					supported = true,
+					is_tir_vim = true,
+				}) then
 				return
 			end
 			debug_entry_point(args)
@@ -225,9 +208,9 @@ local function register_buffer_local_autocmds(augroup, bufnr)
 		buffer = bufnr,
 		callback = guard.guarded(function(args)
 			if buf_state.should_skip(args.buf, {
-				supported = true,
-				is_tir_vim = true,
-			}) then
+					supported = true,
+					is_tir_vim = true,
+				}) then
 				return
 			end
 			ui.special_clear()
@@ -238,40 +221,51 @@ end
 
 local function register_autocmds()
 	local augroup = api.nvim_create_augroup(GROUP_NAME, { clear = true })
+
+	vim.api.nvim_create_autocmd("FileType", {
+		group = augroup,
+		callback = guard.guarded(function(args)
+			if buf_state.should_skip(args.buf, {
+					supported = true,
+				}) then
+				return
+			end
+			debug_entry_point(args)
+			on_filetype(args)
+			clear_buffer_local_autocmds(augroup, args.buf)
+			local _, err = util.resolve_parser(args.buf)
+			if err then
+				-- By leaving the filetype unset, parser resolution will fail immediately.
+				buffer.set(args.buf, buffer.IKEY.FILETYPE, nil)
+				if err.kind == "not_executable" then error(err) end
+				return
+			end
+			register_buffer_local_autocmds(augroup, args.buf)
+		end),
+	})
+
+	api.nvim_create_autocmd("BufReadPost", {
+		group = augroup,
+		callback = guard.guarded(function(args)
+			if
+				buf_state.should_skip(args.buf, {
+					supported = true,
+					no_vscode = true,
+					has_parser = true,
+				})
+			then
+				return
+			end
+			debug_entry_point(args)
+			on_buf_read_post(args)
+		end),
+	})
+
 	vim.api.nvim_create_autocmd("WinClosed", {
 		group = augroup,
 		callback = guard.guarded(function(args)
 			local winid = tonumber(args.match)
 			pcall(ui.clear_matches, winid)
-		end),
-	})
-
-	vim.api.nvim_create_autocmd("FileType", {
-		group = augroup,
-		callback = guard.guarded(function(args)
-			local now_supported = is_configured_filetype(bo[args.buf].filetype)
-			local was_registered = vim.b[args.buf].tirenvi_autocmds_registered == true
-			local active = was_registered or buf_state.is_tir_vim(args.buf)
-
-			if not now_supported and not active then
-				return
-			end
-
-			debug_entry_point(args)
-			on_filetype(args)
-
-			if not now_supported then
-				if vim.b[args.buf].tirenvi_autocmds_registered then
-					api.nvim_clear_autocmds({ group = augroup, buffer = args.buf })
-					vim.b[args.buf].tirenvi_autocmds_registered = nil
-				end
-				return
-			end
-
-			register_buffer_local_autocmds(augroup, args.buf)
-			if not was_registered then
-				on_buf_read_post(args)
-			end
 		end),
 	})
 

--- a/lua/tirenvi/init.lua
+++ b/lua/tirenvi/init.lua
@@ -308,7 +308,7 @@ end
 function M.on_filetype(bufnr)
 	local old_filetype = buffer.get(bufnr, buffer.IKEY.FILETYPE)
 	local new_filetype = bo[bufnr].filetype
-	log.debug("filetype %s -> %s", tostring(old_filetype), tostring(new_filetype))
+	-- log.debug("filetype %s -> %s", tostring(old_filetype), tostring(new_filetype))
 	if old_filetype then
 		if old_filetype ~= new_filetype then
 			to_flat(bufnr)

--- a/lua/tirenvi/state/buf_state.lua
+++ b/lua/tirenvi/state/buf_state.lua
@@ -1,7 +1,7 @@
 local config = require("tirenvi.config")
 local log = require("tirenvi.util.log")
 local errors = require("tirenvi.util.errors")
-local config = require("tirenvi.config")
+local util = require("tirenvi.util.util")
 local buffer = require("tirenvi.state.buffer")
 local tir_vim = require("tirenvi.core.tir_vim")
 
@@ -10,6 +10,7 @@ local M = {}
 local api = vim.api
 local fn = vim.fn
 local bo = vim.bo
+
 --- ensure the buffer has a parser and the parser is executable. for example, it may be a tir-vim buffer.
 ---@param bufnr number
 ---@return boolean
@@ -18,20 +19,8 @@ local function ensure_has_parser(bufnr)
 		log.debug("buftype:%s", bo[bufnr].buftype)
 		return false
 	end
-
-	local filetype = buffer.get(bufnr, buffer.IKEY.FILETYPE)
-	if not filetype then
-		return false
-	end
-
-	local parser = config.parser_map[filetype]
-	if not parser then
-		return false
-	end
-
-	-- For passive checks (autocmd gating), missing executables should only
-	-- skip processing rather than raise user-facing notifications.
-	return fn.executable(parser.executable) == 1
+	local _, err = util.resolve_parser(bufnr)
+	return err == nil
 end
 
 --- has pipe markers. for example, it may be a tir-vim buffer.

--- a/lua/tirenvi/state/buf_state.lua
+++ b/lua/tirenvi/state/buf_state.lua
@@ -1,7 +1,7 @@
 local config = require("tirenvi.config")
 local log = require("tirenvi.util.log")
 local errors = require("tirenvi.util.errors")
-local util = require("tirenvi.util.util")
+local config = require("tirenvi.config")
 local buffer = require("tirenvi.state.buffer")
 local tir_vim = require("tirenvi.core.tir_vim")
 
@@ -18,9 +18,20 @@ local function ensure_has_parser(bufnr)
 		log.debug("buftype:%s", bo[bufnr].buftype)
 		return false
 	end
-	local parser = util.get_parser(bufnr)
-	assert(parser ~= nil, "If no parser exists, an error is raised inside get_parser_name.")
-	return true
+
+	local filetype = buffer.get(bufnr, buffer.IKEY.FILETYPE)
+	if not filetype then
+		return false
+	end
+
+	local parser = config.parser_map[filetype]
+	if not parser then
+		return false
+	end
+
+	-- For passive checks (autocmd gating), missing executables should only
+	-- skip processing rather than raise user-facing notifications.
+	return fn.executable(parser.executable) == 1
 end
 
 --- has pipe markers. for example, it may be a tir-vim buffer.

--- a/lua/tirenvi/util/errors.lua
+++ b/lua/tirenvi/util/errors.lua
@@ -34,11 +34,13 @@ M.ERR = {
 
 --- Create a domain error object.
 ---@param message string
----@return { tag: table, message: string }
-function M.new_domain_error(message)
+---@param kind string|nil
+---@return { tag: table, message: string, kind: string? }
+function M.new_domain_error(message, kind)
 	return {
 		tag = M.DOMAIN_ERROR,
 		message = message,
+		kind = kind,
 	}
 end
 

--- a/lua/tirenvi/util/util.lua
+++ b/lua/tirenvi/util/util.lua
@@ -25,10 +25,9 @@ local bo = vim.bo
 -- private helpers
 
 --- Get parser configuration for a file.
----@param bufnr number
+---@param filetype string
 ---@return Parser|nil
-local function get_parser_for_file(bufnr)
-	local filetype = buffer.get(bufnr, buffer.IKEY.FILETYPE)
+local function get_parser_for_filetype(filetype)
 	if not filetype then
 		return nil
 	end
@@ -115,17 +114,29 @@ function M.assert_no_reserved_marks(fl_lines)
 end
 
 ---@param bufnr number|nil
----@return Parser
-function M.get_parser(bufnr)
+---@return Parser|nil
+---@return string|nil
+function M.resolve_parser(bufnr)
 	bufnr = bufnr or vim.api.nvim_get_current_buf()
-	local parser = get_parser_for_file(bufnr)
-	if parser == nil then
-		local filetype = buffer.get(bufnr, buffer.IKEY.FILETYPE)
-		error(errors.new_domain_error(errors.no_parser_error(filetype)))
+	local filetype = buffer.get(bufnr, buffer.IKEY.FILETYPE)
+	local parser = get_parser_for_filetype(filetype)
+	if not parser then
+		return nil, errors.no_parser_error(filetype)
 	end
 	if fn.executable(parser.executable) ~= 1 then
-		error(errors.new_domain_error(errors.not_found_parser_error(parser)))
+		return parser, errors.not_found_parser_error(parser)
 	end
+	return parser, nil
+end
+
+---@param bufnr number|nil
+---@return Parser
+function M.get_parser(bufnr)
+	local parser, err = M.resolve_parser(bufnr)
+	if err then
+		error(errors.new_domain_error(err))
+	end
+	---@cast parser Parser	
 	return parser
 end
 

--- a/lua/tirenvi/util/util.lua
+++ b/lua/tirenvi/util/util.lua
@@ -115,16 +115,16 @@ end
 
 ---@param bufnr number|nil
 ---@return Parser|nil
----@return string|nil
+---@return { tag: table, message: string, kind: string? }|nil
 function M.resolve_parser(bufnr)
 	bufnr = bufnr or vim.api.nvim_get_current_buf()
 	local filetype = buffer.get(bufnr, buffer.IKEY.FILETYPE)
 	local parser = get_parser_for_filetype(filetype)
 	if not parser then
-		return nil, errors.no_parser_error(filetype)
+		return nil, errors.new_domain_error(errors.no_parser_error(filetype), "no_parser")
 	end
 	if fn.executable(parser.executable) ~= 1 then
-		return parser, errors.not_found_parser_error(parser)
+		return parser, errors.new_domain_error(errors.not_found_parser_error(parser), "not_executable")
 	end
 	return parser, nil
 end
@@ -134,7 +134,7 @@ end
 function M.get_parser(bufnr)
 	local parser, err = M.resolve_parser(bufnr)
 	if err then
-		error(errors.new_domain_error(err))
+		error(err)
 	end
 	---@cast parser Parser	
 	return parser

--- a/lua/tirenvi/util/util.lua
+++ b/lua/tirenvi/util/util.lua
@@ -120,7 +120,8 @@ function M.get_parser(bufnr)
 	bufnr = bufnr or vim.api.nvim_get_current_buf()
 	local parser = get_parser_for_file(bufnr)
 	if parser == nil then
-		error(errors.new_domain_error(""))
+		local filetype = buffer.get(bufnr, buffer.IKEY.FILETYPE)
+		error(errors.new_domain_error(errors.no_parser_error(filetype)))
 	end
 	if fn.executable(parser.executable) ~= 1 then
 		error(errors.new_domain_error(errors.not_found_parser_error(parser)))

--- a/tests/cases/ut/util/log-file/out-expected.txt
+++ b/tests/cases/ut/util/log-file/out-expected.txt
@@ -2,6 +2,6 @@
 [TIR][WARN][[string ":lua"]:15] 3.14
 [TIR][DEBUG][[string ":lua"]:17] <boolean> false
 [TIR][🟧PROBE][[string ":lua"]:18] -0.003
-[TIR][DEBUG][autocmd.lua:95] ===+===+===+===+=== VimLeavePre(1)text ===+===+===+===+===
-[TIR][DEBUG][autocmd.lua:95] ===+===+===+===+=== VimLeavePre(1)text ===+===+===+===+===
-[TIR][DEBUG][autocmd.lua:95] ===+===+===+===+=== VimLeave(1)text ===+===+===+===+===
+[TIR][DEBUG][autocmd.lua:101] ===+===+===+===+=== VimLeavePre(1)text ===+===+===+===+===
+[TIR][DEBUG][autocmd.lua:101] ===+===+===+===+=== VimLeavePre(1)text ===+===+===+===+===
+[TIR][DEBUG][autocmd.lua:101] ===+===+===+===+=== VimLeave(1)text ===+===+===+===+===


### PR DESCRIPTION
This PR finalizes and refines the work originally proposed by @ph1losof in #56.

- Fix empty error notifications
- Improve performance with buffer-local autocmds
- Simplify autocmd lifecycle
- Refactor parser handling

Thanks to @ph1losof for the original implementation and design direction.