### PR TITLE
refactor: introduce Range abstraction and simplify entrypoint logic

### DIFF
--- a/lua/tirenvi/core/block.lua
+++ b/lua/tirenvi/core/block.lua
@@ -3,7 +3,7 @@ local Record = require("tirenvi.core.record")
 local config = require("tirenvi.config")
 local Attr = require("tirenvi.core.attr")
 local util = require("tirenvi.util.util")
-local range = require("tirenvi.util.range")
+local Range = require("tirenvi.util.range")
 local log = require("tirenvi.util.log")
 
 local M = {}
@@ -265,8 +265,8 @@ end
 local function change_width(attr, icol, start_col, operator, count, col)
     local column = attr.columns[icol]
     local old_width = column.width
-    local cel_range = { first = start_col, last = start_col + old_width }
-    if range.intersect(cel_range, col) then
+    local cel_range = Range.new(start_col, start_col + old_width)
+    if cel_range:intersect(col) then
         local new_width = get_new_width(operator, count, old_width)
         Attr.grid.set_width(attr, icol, new_width)
     end

--- a/lua/tirenvi/core/tir_vim.lua
+++ b/lua/tirenvi/core/tir_vim.lua
@@ -1,6 +1,7 @@
 local config = require("tirenvi.config")
 local util = require("tirenvi.util.util")
 local buffer = require("tirenvi.state.buffer")
+local Range = require("tirenvi.util.range")
 local log = require("tirenvi.util.log")
 
 local pipen = config.marks.pipe
@@ -215,10 +216,9 @@ function M.get_block_rect(line_provider, count, is_around, allow_plain)
     local end_index = colIndex + count
     end_index = math.min(end_index, #bbyte_pos)
     return {
-        start_row = trow,
-        end_row   = brow,
-        start_col = tbyte_pos[colIndex] + (is_around and 0 or #pipen),
-        end_col   = bbyte_pos[end_index] - 1
+        row = Range.new(trow, brow),
+        col = Range.new(tbyte_pos[colIndex] + (is_around and 0 or #pipen),
+            bbyte_pos[end_index] - 1),
     }
 end
 

--- a/lua/tirenvi/editor/commands.lua
+++ b/lua/tirenvi/editor/commands.lua
@@ -7,6 +7,7 @@ local init = require("tirenvi.init")
 local notify = require("tirenvi.util.notify")
 local log = require("tirenvi.util.log")
 local errors = require("tirenvi.util.errors")
+local Range = require("tirenvi.util.range")
 local ui = require("tirenvi.ui")
 
 -- module
@@ -51,6 +52,8 @@ local function cmd_hbar(bufnr, opts)
 	init.hbar(bufnr)
 end
 
+---@param opts {[string]:any}
+---@return Rect
 local function get_rect(opts)
 	local row_start = opts.line1
 	local row_end   = opts.line2
@@ -70,14 +73,8 @@ local function get_rect(opts)
 		col_end   = col
 	end
 	return {
-		row = {
-			first = math.min(row_start, row_end),
-			last  = math.max(row_start, row_end),
-		},
-		col = {
-			first = math.min(col_start, col_end),
-			last  = math.max(col_start, col_end),
-		},
+		row = Range.new(math.min(row_start, row_end), math.max(row_start, row_end)),
+		col = Range.new(math.min(col_start, col_end), math.max(col_start, col_end)),
 	}
 end
 

--- a/lua/tirenvi/editor/textobj.lua
+++ b/lua/tirenvi/editor/textobj.lua
@@ -18,10 +18,10 @@ local function setup_vl(line_provider, is_around)
     if not pos then
         return
     end
-    vim.api.nvim_win_set_cursor(0, { pos.start_row, pos.start_col - 1, })
+    vim.api.nvim_win_set_cursor(0, { pos.row.first, pos.col.first - 1, })
     vim.api.nvim_feedkeys(vim.keycode("<C-v>"), "n", false)
     vim.cmd("normal! o")
-    vim.api.nvim_win_set_cursor(0, { pos.end_row, pos.end_col - 1, })
+    vim.api.nvim_win_set_cursor(0, { pos.row.last, pos.col.last - 1, })
 end
 
 local function setup_vil()

--- a/lua/tirenvi/init.lua
+++ b/lua/tirenvi/init.lua
@@ -116,7 +116,7 @@ end
 ---@param count integer
 ---@param rect Rect
 local function change_table_width(operator, count, rect)
-	log.debug("row[%d-%d], col[%d-%d]", rect.row.first, rect.row.last, rect.col.first, rect.col.last)
+	log.debug("row%s, col%s", rect.row:short(), rect.col:short())
 	local bufnr, blocks = get_blocks(rect.row)
 	Blocks.change_width(blocks, operator, count, rect.col)
 	local vi_lines = vim_parser.unparse(blocks)

--- a/lua/tirenvi/render.lua
+++ b/lua/tirenvi/render.lua
@@ -1,25 +1,25 @@
 local config = require("tirenvi.config")
 local ns = require("tirenvi.ns")
 local buffer = require("tirenvi.state.buffer")
+local Range = require("tirenvi.util.range")
 local log = require("tirenvi.util.log")
 
 local M = {}
 
 ---@param bufnr number
----@param first integer
----@param last integer
+---@param range Range
 ---@param id integer
-function M.set_range(bufnr, first, last, id)
-    last = math.max(first, last) -- If a line is deleted, first > last, so we normalize it
-    last = math.min(last, buffer.line_count(bufnr) - 1)
-    local line = buffer.get_line(bufnr, last)
+function M.set_range(bufnr, range, id)
+    range.last = math.max(range.first, range.last) -- If a line is deleted, first > last, so we normalize it
+    range.last = math.min(range.last, buffer.line_count(bufnr) - 1)
+    local line = buffer.get_line(bufnr, range.last)
     local end_col = #line
     local opts = {
         id = id,
         strict = false,
         right_gravity = false,
         end_right_gravity = true,
-        end_row = last,
+        end_row = range.last,
         end_col = end_col,
         invalidate = false,
     }
@@ -31,7 +31,7 @@ function M.set_range(bufnr, first, last, id)
         opts.sign_text = tostring(id):sub(-2)
         opts.sign_hl_group = "ErrorMsg"
     end
-    vim.api.nvim_buf_set_extmark(bufnr, ns.INVALID, first, 0, opts)
+    vim.api.nvim_buf_set_extmark(bufnr, ns.INVALID, range.first, 0, opts)
 end
 
 ---@param bufnr number
@@ -48,7 +48,7 @@ function M.get_range(bufnr)
     for index = 1, #extmarks do
         local start_row = extmarks[index][2]
         local end_row = extmarks[index][4].end_row
-        ranges[#ranges + 1] = { first = start_row, last = end_row }
+        ranges[#ranges + 1] = Range.new(start_row, end_row)
     end
     return ranges
 end

--- a/lua/tirenvi/state/buffer.lua
+++ b/lua/tirenvi/state/buffer.lua
@@ -3,6 +3,7 @@
 -----------------------------------------------------------------------
 
 ----- dependencies
+local Range = require("tirenvi.util.range")
 local log   = require("tirenvi.util.log")
 
 local M     = {}
@@ -162,7 +163,9 @@ end
 ---@param lines string[]
 ---@param no_undo boolean|nil
 function M.set_lines(bufnr, i_start, i_end, lines, no_undo)
-	log.debug("=== set_lines(%d, %d)[1]%s [%d]%s", i_start, i_end, tostring(lines[1]), #lines, tostring(lines[#lines]))
+	local range = Range.new(i_start, i_end)
+	log.debug("=== set_lines%s[1]%s [%d]%s", range:short(), tostring(lines[1]), #lines,
+		tostring(lines[#lines]))
 	log.debug(M.get_state(bufnr))
 	M.set(bufnr, M.IKEY.PATCH_DEPTH, M.get(bufnr, M.IKEY.PATCH_DEPTH) + 1)
 	local ok, err = pcall(set_lines, bufnr, i_start, i_end, lines, no_undo)

--- a/lua/tirenvi/types.lua
+++ b/lua/tirenvi/types.lua
@@ -70,10 +70,6 @@
 ---@field row Range
 ---@field col Range
 
----@class Range
----@field first integer
----@field last integer
-
 ---@class LineProvider
 ---@field get_line fun(row: integer): string|nil
 ---@field line_count fun(): integer

--- a/lua/tirenvi/ui.lua
+++ b/lua/tirenvi/ui.lua
@@ -1,5 +1,5 @@
 local config = require("tirenvi.config")
-local range = require("tirenvi.util.range")
+local Range = require("tirenvi.util.range")
 local render = require("tirenvi.render")
 local buffer = require("tirenvi.state.buffer")
 local tir_vim = require("tirenvi.core.tir_vim")
@@ -149,7 +149,7 @@ end
 ---@param ranges Range[]
 function M.diagnostic_set(bufnr, ranges)
     for index, range in ipairs(ranges) do
-        render.set_range(bufnr, range.first, range.last, index)
+        render.set_range(bufnr, range, index)
     end
 end
 
@@ -177,9 +177,9 @@ function M.diagnostic_get(bufnr, first, last)
     if first then
         ---@cast last integer
         last = expand_continue_lines(bufnr, first, last)
-        ranges[#ranges + 1] = { first = first, last = last - 1 }
+        ranges[#ranges + 1] = Range.new(first, last - 1)
     end
-    return range.union(ranges)
+    return Range.union(ranges)
 end
 
 ---@param bufnr number

--- a/lua/tirenvi/util/range.lua
+++ b/lua/tirenvi/util/range.lua
@@ -1,6 +1,7 @@
-local M = {}
+---@class Range
+local Range = {}
+Range.__index = Range
 
----@param ranges Range[]
 ---@return Range[]
 local function sort_range(ranges)
     table.sort(ranges, function(prev, next)
@@ -12,24 +13,36 @@ end
 ---@param prev Range
 ---@param next Range
 ---@return Range|nil
-local function union_range_2(prev, next)
+local function union_range(prev, next)
     if prev.last + 1 < next.first then
         return nil
     end
-    return {
-        first = math.min(prev.first, next.first),
-        last  = math.max(prev.last, next.last),
-    }
+    return Range.new(math.min(prev.first, next.first), math.max(prev.last, next.last))
 end
 
----@param source Range
+---@param first integer
+---@param last integer
+---@return Range
+function Range.new(first, last)
+    return setmetatable({
+        first = first,
+        last = last,
+    }, Range)
+end
+
+---@return string
+function Range:short()
+    return string.format("(%d,%d)", self.first, self.last)
+end
+
+---@param self Range
 ---@param target Range
 ---@return boolean
-function M.intersect(source, target)
-    if source.last < target.first then
+function Range:intersect(target)
+    if self.last < target.first then
         return false
     end
-    if target.last < source.first then
+    if target.last < self.first then
         return false
     end
     return true
@@ -37,14 +50,14 @@ end
 
 ---@param ranges Range[]
 ---@return Range[]
-function M.union(ranges)
+function Range.union(ranges)
     if #ranges == 0 then
         return ranges
     end
     ranges = sort_range(ranges)
     local unions = { ranges[1] }
     for index = 2, #ranges do
-        local merged = union_range_2(unions[#unions], ranges[index])
+        local merged = union_range(unions[#unions], ranges[index])
         if merged then
             unions[#unions] = merged
         else
@@ -54,4 +67,4 @@ function M.union(ranges)
     return unions
 end
 
-return M
+return Range

--- a/tests/cases/ut/state/buffer/out-expected.txt
+++ b/tests/cases/ut/state/buffer/out-expected.txt
@@ -1,23 +1,23 @@
 === MESSAGE ===
 [TIR][🟧PROBE][[string ":lua"]:14] buffer.get_lines(0, 0, -1)
-[TIR][DEBUG][buffer.lua:84] ===== cache [1,] (0, 21), lines[1]=0, line[21]=20
+[TIR][DEBUG][buffer.lua:85] ===== cache [1,] (0, 21), lines[1]=0, line[21]=20
 [TIR][DEBUG][[string ":lua"]:16] <table> { "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20" }
 [TIR][DEBUG][[string ":lua"]:18] <table> { "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20" }
 [TIR][🟧PROBE][[string ":lua"]:19] buffer.get_lines(0, -100, 100)
 [TIR][DEBUG][[string ":lua"]:21] <table> { "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20" }
 [TIR][🟧PROBE][[string ":lua"]:22] clear & buffer.get_lines(0, 9, 13)
-[TIR][DEBUG][buffer.lua:84] ===== cache [1,] (6, 16), lines[1]=6, line[10]=15
+[TIR][DEBUG][buffer.lua:85] ===== cache [1,] (6, 16), lines[1]=6, line[10]=15
 [TIR][DEBUG][[string ":lua"]:25] <table> { "9", "10", "11", "12" }
 [TIR][🟧PROBE][[string ":lua"]:26] buffer.get_line(0, 6)
 [TIR][DEBUG][[string ":lua"]:28] 6
 [TIR][🟧PROBE][[string ":lua"]:29] buffer.get_line(0, 2)
-[TIR][DEBUG][buffer.lua:84] ===== cache [1,] (0, 6), lines[1]=0, line[6]=5
+[TIR][DEBUG][buffer.lua:85] ===== cache [1,] (0, 6), lines[1]=0, line[6]=5
 [TIR][DEBUG][[string ":lua"]:31] 2
 [TIR][🟧PROBE][[string ":lua"]:32] buffer.get_line(0, 19)
-[TIR][DEBUG][buffer.lua:84] ===== cache [1,] (15, 21), lines[1]=15, line[6]=20
+[TIR][DEBUG][buffer.lua:85] ===== cache [1,] (15, 21), lines[1]=15, line[6]=20
 [TIR][DEBUG][[string ":lua"]:34] 19
 [TIR][🟧PROBE][[string ":lua"]:35] buffer.get_line(0, 10)
-[TIR][DEBUG][buffer.lua:84] ===== cache [1,] (4, 11), lines[1]=4, line[7]=10
+[TIR][DEBUG][buffer.lua:85] ===== cache [1,] (4, 11), lines[1]=4, line[7]=10
 [TIR][DEBUG][[string ":lua"]:37] 10
 [TIR][🟧PROBE][[string ":lua"]:38] buffer.get_line(0, -1)
 [TIR][DEBUG][[string ":lua"]:40] nil


### PR DESCRIPTION
## Overview

This PR introduces a `Range` abstraction to represent and handle spans defined by start/end positions.

---

## Changes

* Add `Range` class (`first`, `last`)
* Replace raw `(start, end_)` pairs with `Range` where appropriate
* Add basic utility methods (e.g. `short`, `intersect`)
* Adjust internal code to use `Range.new(...)`

---

## Motivation

* Improve readability by making range semantics explicit
* Reduce bugs caused by mismatched or misordered `(start, end_)` pairs
* Provide a foundation for future range operations (e.g. union, normalization)

---

## Notes

* This is a refactor with no intended behavior changes
* Focus is on internal consistency and abstraction

---

## Future Work

* Extend `Range` utilities (union, normalize, etc.)
* Gradually migrate remaining range-like usages
