### PR TITLE
docs: refine README and clarify vim-repeat integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,12 +102,12 @@ even if they contain temporary structural inconsistencies.
 ```lua
 {
   "kibi2/tirenvi.nvim",
+  dependencies = {
+    "tpope/vim-repeat", -- optional: enables '.' repeat for column width operations
+  },
   config = function()
     require("tirenvi").setup()
   end,
-  dependencies = {
-    "tpope/vim-repeat", -- optional
-  },
 }
 ```
 
@@ -115,6 +115,9 @@ even if they contain temporary structural inconsistencies.
 
 ```vim
 Plug 'kibi2/tirenvi.nvim'
+
+" Optional: enables '.' repeat for column width operations
+Plug 'tpope/vim-repeat'
 ```
 
 ### Requirements


### PR DESCRIPTION
This PR refines the README for the v0.3.0 release.

### Changes

- Clarify optional `vim-repeat` dependency
- Align lazy.nvim and vim-plug installation examples
- Improve wording and overall structure

The goal is to make installation and key features (especially `.` repeat for column width operations) more discoverable and consistent across setups.