### PR TITLE
docs(readme): improve intro and positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,19 +6,24 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 ![Neovim](https://img.shields.io/badge/Neovim-0.9+-57A143?logo=neovim)
 
-> Structural table editing for Neovim — pure text, always valid.
+> Markdown & CSV table editor for Neovim — structural editing, pure text, always valid.
+
+Supports Markdown and CSV out of the box,
+and can be extended to other formats via custom parsers.
 
 ## Markdown (GFM)
 
 ![demo gif](./demo.gif)
 
-Raw Markdown → structured table view → adjust column widths → edit cells → back to raw Markdown (lossless round-trip)
+Edit Markdown tables structurally.
+
+Raw → aligned → edit → back to raw (lossless).
 
 ## CSV / TSV
 
 ![demo gif](./demo_csv.gif)
 
-Raw CSV → structured table view → adjust column widths → edit cells → back to raw CSV (lossless round-trip)
+Raw → aligned → edit → back to raw (lossless).
 
 ## Design Philosophy
 
@@ -31,13 +36,10 @@ Raw CSV → structured table view → adjust column widths → edit cells → ba
 
 ## Why?
 
-CSV and Markdown are text.
+Markdown and CSV are text — but they represent structure.
 
-But they also represent structure.
-
-Tirenvi lets you edit structured tabular data
-without leaving Vim’s native editing model —
-while preserving structural integrity.
+Tirenvi lets you edit tabular data structurally,
+while staying in Vim’s native editing model.
 
 You edit text.
 Tirenvi preserves structure.


### PR DESCRIPTION
## Summary

Improve README introduction for better clarity and discoverability.

## Changes

- Update tagline to include Markdown & CSV explicitly
- Emphasize "table editor" use case
- Add short explanation of structural editing and lossless round-trip
- Simplify demo descriptions

## Motivation

The previous intro was slightly abstract and didn't clearly convey:
- what formats are supported
- what the plugin actually does

This change makes the core use case immediately clear for first-time visitors
and improves search visibility (GitHub, neovimcraft, etc).

## Notes

No functional changes.