### PR TITLE
fix: stabilize extmark rendering with scheduled updates

### DIFF
--- a/lua/tirenvi/editor/commands.lua
+++ b/lua/tirenvi/editor/commands.lua
@@ -168,7 +168,7 @@ local commands = {
 	redraw = cmd_format,
 	_format = cmd_format,
 	width = cmd_width,
-	["_repair"] = cmd_repair,
+	_repair = cmd_repair,
 }
 
 

--- a/lua/tirenvi/io/attr_store.lua
+++ b/lua/tirenvi/io/attr_store.lua
@@ -39,13 +39,23 @@ local function show_debug_marks(bufnr, attr, iattr)
     vim.api.nvim_buf_set_extmark(bufnr, namespaces.ATTR, start0, 0, opts)
 end
 
+---@param bufnr number
+local function set_attrs(bufnr, attrs)
+    M.clear(bufnr)
+    buffer.set(bufnr, buffer.IKEY.ATTRS, attrs)
+    vim.schedule(function()
+        for iattr, attr in ipairs(attrs) do
+            show_debug_marks(bufnr, attr, iattr)
+        end
+    end)
+end
 
 -- Public API
 
 ---@param ctx Context
 ---@param attrs Attr[]
 function M.write(ctx, attrs)
-    M.set_attrs(ctx.bufnr, attrs)
+    set_attrs(ctx.bufnr, attrs)
 end
 
 ---@param ctx Context
@@ -56,23 +66,16 @@ end
 
 ---@param bufnr number
 function M.clear(bufnr)
-    vim.api.nvim_buf_clear_namespace(bufnr, namespaces.ATTR, 0, -1)
     buffer.set(bufnr, buffer.IKEY.ATTRS, nil)
+    vim.schedule(function()
+        vim.api.nvim_buf_clear_namespace(bufnr, namespaces.ATTR, 0, -1)
+    end)
 end
 
 ---@param bufnr number
 ---@return Attr[]|nil
 function M.get_attrs(bufnr)
     return buffer.get(bufnr, buffer.IKEY.ATTRS)
-end
-
----@param bufnr number
-function M.set_attrs(bufnr, attrs)
-    M.clear(bufnr)
-    buffer.set(bufnr, buffer.IKEY.ATTRS, attrs)
-    for iattr, attr in ipairs(attrs) do
-        show_debug_marks(bufnr, attr, iattr)
-    end
 end
 
 return M


### PR DESCRIPTION
## Summary

Extmark rendering occasionally became unstable when updated immediately after buffer changes.

This patch schedules extmark updates using `vim.schedule()` so they run after the current redraw/update cycle.

## Symptoms

* virt_text position occasionally shifted
* extmarks sometimes appeared at incorrect positions
* rendering became stable after delayed execution

## Notes

This mainly affects extmarks using `virt_text_pos = "eol_right_align"` and updates triggered from buffer change callbacks such as `on_lines`.

The issue appears to be related to redraw timing and extmark position recalculation inside Neovim.
