### PR TITLE
Refactor/range slice unification

### DIFF
--- a/lua/tirenvi/app/pipeline.lua
+++ b/lua/tirenvi/app/pipeline.lua
@@ -42,7 +42,7 @@ end
 ---@param req_r Request
 ---@param range3 Range3|nil
 ---@return Document|nil
-local function vim_to_vdoc(ctx, req_r, range3)
+local function vim_to_vdoc_text_driven(ctx, req_r, range3)
     reader.read(ctx, req_r)
     if not Attrs.has_range(req_r.attrs) then
         return nil
@@ -50,7 +50,7 @@ local function vim_to_vdoc(ctx, req_r, range3)
     log.watch("ATTR", Attrs.debug_attrs(req_r.attrs, "CHACHED ATTRS:"))
     req_r.attrs = Attrs.update_range(req_r.attrs or {}, range3)
     if range3 then log.watch("ATTR", Attrs.debug_attrs(req_r.attrs, "0UPDATE CHACHED:")) end
-    local vim_doc = vim_parser.parse(ctx, req_r, range3)
+    local vim_doc = vim_parser.parse_text_driven(ctx, req_r, range3)
     log.watch("ATTR", Document.debug_attrs(vim_doc, "1DOC ATTR:"))
     return vim_doc
 end
@@ -58,13 +58,13 @@ end
 ---@param ctx Context
 ---@param req_r Request
 ---@return Document|nil
-local function vim_to_vdoc_format(ctx, req_r)
+local function vim_to_vdoc_attr_driven(ctx, req_r)
     reader.read(ctx, req_r)
     if not Attrs.has_range(req_r.attrs) then
         return nil
     end
     log.watch("ATTR", Attrs.debug_attrs(req_r.attrs, "CHACHED ATTRS:"))
-    local vim_doc = vim_parser.parse_format(ctx, req_r)
+    local vim_doc = vim_parser.parse_attr_driven(ctx, req_r)
     log.watch("ATTR", Document.debug_attrs(vim_doc, "1DOC ATTR:"))
     return vim_doc
 end
@@ -72,8 +72,8 @@ end
 ---@param ctx Context
 ---@param req_r Request
 ---@return Document|nil
-local function vim_to_doc(ctx, req_r)
-    local vim_doc = vim_to_vdoc(ctx, req_r)
+local function vim_to_doc_text_driven(ctx, req_r)
+    local vim_doc = vim_to_vdoc_text_driven(ctx, req_r)
     if not vim_doc then
         return nil
     end
@@ -87,8 +87,8 @@ end
 ---@param no_normalize boolean -- If true, skip nomalizing.
 -- Prevents line count changes that would break put(); used for repair.
 ---@return Document|nil
-local function vim_to_doc_format(ctx, req_r, no_normalize)
-    local vim_doc = vim_to_vdoc_format(ctx, req_r)
+local function vim_to_doc_attrs_driven(ctx, req_r, no_normalize)
+    local vim_doc = vim_to_vdoc_attr_driven(ctx, req_r)
     if not vim_doc or not Blocks.has_grid(vim_doc.blocks) then
         return nil
     end
@@ -147,7 +147,7 @@ end
 ---@param no_undo boolean|nil
 function M.to_flat(ctx, no_undo)
     local req_r = Request.from_range(Range.WHOLE)
-    local doc = vim_to_doc(ctx, req_r)
+    local doc = vim_to_doc_text_driven(ctx, req_r)
     if doc and Blocks.has_grid(doc.blocks) then
         doc_to_flat(ctx, req_r, doc, no_undo)
     end
@@ -160,7 +160,7 @@ function M.cmd_width(ctx, sel, width_op)
     invalid.clear(ctx.bufnr)
     log.debug("row%s, col%s", Range.short(sel.row), Range.short(sel.col))
     local req_r = Request.from_range(sel.row)
-    local doc = vim_to_doc(ctx, req_r)
+    local doc = vim_to_doc_text_driven(ctx, req_r)
     if doc and Blocks.has_grid(doc.blocks) then
         Blocks.change_width(doc.blocks, sel.col, width_op)
         local vim_doc = Document.to_vim(doc)
@@ -175,7 +175,7 @@ function M.cmd_format(ctx, no_normalize, no_undo)
     invalid.clear(ctx.bufnr)
     no_normalize = no_normalize or false
     local req_r = Request.from_range(Range.WHOLE)
-    local doc = vim_to_doc_format(ctx, req_r, no_normalize)
+    local doc = vim_to_doc_attrs_driven(ctx, req_r, no_normalize)
     if not doc or not Blocks.has_grid(doc.blocks) then
         return
     end
@@ -187,7 +187,7 @@ end
 ---@param range3 Range3
 function M.update_attrs(ctx, range3)
     local req_r = Request.from_range(Range3.get_new_range(range3))
-    local vim_doc = vim_to_vdoc(ctx, req_r, range3)
+    local vim_doc = vim_to_vdoc_text_driven(ctx, req_r, range3)
     if not vim_doc then
         return nil
     end

--- a/lua/tirenvi/core/attr.lua
+++ b/lua/tirenvi/core/attr.lua
@@ -4,6 +4,7 @@ local Range = require("tirenvi.util.range")
 local log = require("tirenvi.util.log")
 
 local M = {}
+
 M.plain = {}
 M.grid = {}
 

--- a/lua/tirenvi/core/attrs.lua
+++ b/lua/tirenvi/core/attrs.lua
@@ -13,16 +13,6 @@ local api   = vim.api
 -----------------------------------------------------------------------
 
 ---@param self Attr[]
----@param range Range
----@return Attr[]
----@return Attr[]
-local function split(self, range)
-    local range1 = Range.from_lua(1, range.first - 1)
-    local range2 = Range.from_lua(range.last + 1, math.huge)
-    return M.slice(self, range1), M.slice(self, range2)
-end
-
----@param self Attr[]
 ---@return Attr[]
 local function connect(self)
     local attrs = { self[1] }
@@ -111,7 +101,7 @@ end
 ---@param doc_attrs Attr[]
 ---@return Attr[]
 function M:replace_attrs(range, doc_attrs)
-    local attrs1, attrs3 = split(self, range)
+    local attrs1, _, attrs3 = Range.split(self, range)
     local attrs = attrs1
     log.watch("ATTR", range)
     log.watch("ATTR", M.debug_attrs(self, "MERGE ORIGIN:"))
@@ -200,25 +190,6 @@ end
 ---@return Attr|nil
 function M:get(irow)
     return self[get_index(self, 1, irow)]
-end
-
----@param self Attr[]
----@param range Range
----@return Attr[]
-function M:slice(range)
-    local attrs = {}
-    if Range.is_empty(range) then
-        return attrs
-    end
-    for _, attr in ipairs(self) do
-        if Range.intersect(attr.range, range) then
-            local new_attr = vim.deepcopy(attr)
-            new_attr.range.first = math.max(new_attr.range.first, range.first)
-            new_attr.range.last = math.min(new_attr.range.last, range.last)
-            attrs[#attrs + 1] = new_attr
-        end
-    end
-    return attrs
 end
 
 return M

--- a/lua/tirenvi/core/blocks.lua
+++ b/lua/tirenvi/core/blocks.lua
@@ -51,7 +51,7 @@ end
 --- Split NDJSON records into plain/grid blocks.
 ---@param records Ndjson[]
 ---@return Blocks
-local function build_blocks_from_records(records)
+local function build_blocks_text_driven(records)
 	local self = {}
 	---@type Block
 	local block = Block.new()
@@ -83,7 +83,7 @@ end
 ---@param records Ndjson[]
 ---@param attrs Attr[]
 ---@return Blocks
-local function build_blocks_from_attrs(records, attrs)
+local function build_blocks_attr_driven(records, attrs)
 	local self = {}
 	for iattr, attr in ipairs(attrs) do
 		local block = Block.new()
@@ -120,9 +120,9 @@ end
 ---@return Blocks
 local function build_blocks(records, attrs)
 	if attrs then
-		return build_blocks_from_attrs(records, attrs)
+		return build_blocks_attr_driven(records, attrs)
 	else
-		return build_blocks_from_records(records)
+		return build_blocks_text_driven(records)
 	end
 end
 

--- a/lua/tirenvi/core/reconcile.lua
+++ b/lua/tirenvi/core/reconcile.lua
@@ -67,7 +67,7 @@ local function log_watch(bufnr, message, range3, inv_range)
 		"[tree:%d->%d]%s%s",
 		pre,
 		next,
-		range3:short(),
+		Range3.short(range3),
 		no_ext
 	)
 	log.watch("UNDO", message .. status)

--- a/lua/tirenvi/core/reconcile.lua
+++ b/lua/tirenvi/core/reconcile.lua
@@ -144,24 +144,31 @@ local function get_new_range(bufnr, range3)
 	return new_range
 end
 
+---@param bufnr number
+---@param inv_ranges Range[]
+---@param range3 Range3|nil
+local function update_ranges(bufnr, inv_ranges, range3)
+	Range3.update_ranges(range3, inv_ranges)
+	local new_range = get_new_range(bufnr, range3)
+	inv_ranges[#inv_ranges + 1] = new_range
+	inv_ranges = Range.union(inv_ranges)
+end
+
 ---@param ctx Context
 ---@param range3 Range3|nil
 local function handle_request(ctx, range3)
 	local bufnr = ctx.bufnr
-	local inv_ranges = invalid.get_ranges(ctx.bufnr)
+	local inv_ranges = invalid.get_ranges(bufnr)
+	local repair = is_repair(ctx, range3, inv_ranges)
 	invalid.clear(bufnr)
-	Range3.update_ranges(range3, inv_ranges)
-	local new_range = get_new_range(bufnr, range3)
-	local format_ranges = vim.deepcopy(inv_ranges)
-	format_ranges[#format_ranges + 1] = new_range
-	format_ranges = Range.union(format_ranges)
-	if #format_ranges == 0 then
+	update_ranges(bufnr, inv_ranges, range3)
+	if #inv_ranges == 0 then
 		return
 	end
-	if is_repair(ctx, range3, inv_ranges) then
-		schedule_new_range(ctx, format_ranges)
+	if repair then
+		schedule_new_range(ctx, inv_ranges)
 	else
-		invalid.set_ranges(bufnr, format_ranges)
+		invalid.set_ranges(bufnr, inv_ranges)
 	end
 end
 

--- a/lua/tirenvi/init.lua
+++ b/lua/tirenvi/init.lua
@@ -240,7 +240,7 @@ function M.on_filetype(ctx)
 	end
 	pipeline.to_flat(ctx)
 	buffer.set(ctx.bufnr, buffer.IKEY.FILETYPE, new_filetype)
-	attr_store.clear(ctx.bufnr)
+	attr_store.write(ctx, nil)
 	ctx = Context.from_buf(ctx.bufnr)
 	if not ctx.parser then
 		buffer.set(ctx.bufnr, buffer.IKEY.FILETYPE, nil)

--- a/lua/tirenvi/init.lua
+++ b/lua/tirenvi/init.lua
@@ -9,8 +9,8 @@ local attr_store = require("tirenvi.io.attr_store")
 local writer = require("tirenvi.io.writer")
 local reader = require("tirenvi.io.reader")
 local tir_vim = require("tirenvi.core.tir_vim")
-local Blocks = require("tirenvi.core.blocks")
 local Range = require("tirenvi.util.range")
+local Range3 = require("tirenvi.util.range3")
 local util = require("tirenvi.util.util")
 local notify = require("tirenvi.util.notify")
 local log = require("tirenvi.util.log")
@@ -218,7 +218,7 @@ end
 ---@param ctx Context
 ---@param range3 Range3
 function M.on_lines(ctx, range3)
-	log.watch("UNDO", "===+=== ENTRY on_lines[#%d]%s", ctx.bufnr, range3:short())
+	log.watch("UNDO", "===+=== ENTRY on_lines[#%d]%s", ctx.bufnr, Range3.short(range3))
 	pipeline.update_attrs(ctx, range3)
 	reconcile.handle(ctx, range3)
 end

--- a/lua/tirenvi/io/attr_store.lua
+++ b/lua/tirenvi/io/attr_store.lua
@@ -40,20 +40,23 @@ local function show_debug_marks(bufnr, attr, iattr)
 end
 
 ---@param bufnr number
+---@param attrs Attr[]|nil
 local function set_attrs(bufnr, attrs)
-    M.clear(bufnr)
     buffer.set(bufnr, buffer.IKEY.ATTRS, attrs)
     vim.schedule(function()
-        for iattr, attr in ipairs(attrs) do
+        vim.api.nvim_buf_clear_namespace(bufnr, namespaces.ATTR, 0, -1)
+        for iattr, attr in ipairs(attrs or {}) do
             show_debug_marks(bufnr, attr, iattr)
         end
     end)
 end
 
+-----------------------------------------------------------------------
 -- Public API
+-----------------------------------------------------------------------
 
 ---@param ctx Context
----@param attrs Attr[]
+---@param attrs Attr[]|nil
 function M.write(ctx, attrs)
     set_attrs(ctx.bufnr, attrs)
 end
@@ -61,21 +64,7 @@ end
 ---@param ctx Context
 ---@param req Request
 function M.read(ctx, req)
-    req.attrs = M.get_attrs(ctx.bufnr)
-end
-
----@param bufnr number
-function M.clear(bufnr)
-    buffer.set(bufnr, buffer.IKEY.ATTRS, nil)
-    vim.schedule(function()
-        vim.api.nvim_buf_clear_namespace(bufnr, namespaces.ATTR, 0, -1)
-    end)
-end
-
----@param bufnr number
----@return Attr[]|nil
-function M.get_attrs(bufnr)
-    return buffer.get(bufnr, buffer.IKEY.ATTRS)
+    req.attrs = buffer.get(ctx.bufnr, buffer.IKEY.ATTRS)
 end
 
 return M

--- a/lua/tirenvi/io/invalid.lua
+++ b/lua/tirenvi/io/invalid.lua
@@ -49,13 +49,7 @@ end
 ---@param bufnr number
 ---@return Range[]
 function M.get_ranges(bufnr)
-    local ranges = buffer.get(bufnr, buffer.IKEY.INVALID) or {}
-    local new_ranges = {}
-    -- Methods are lost during serialization, so reconstruct via the constructor.
-    for _, range in ipairs(ranges) do
-        new_ranges[#new_ranges + 1] = Range.from_lua(range.first, range.last)
-    end
-    return new_ranges
+    return buffer.get(bufnr, buffer.IKEY.INVALID) or {}
 end
 
 ---@param bufnr number

--- a/lua/tirenvi/io/invalid.lua
+++ b/lua/tirenvi/io/invalid.lua
@@ -51,6 +51,7 @@ end
 function M.get_ranges(bufnr)
     local ranges = buffer.get(bufnr, buffer.IKEY.INVALID) or {}
     local new_ranges = {}
+    -- Methods are lost during serialization, so reconstruct via the constructor.
     for _, range in ipairs(ranges) do
         new_ranges[#new_ranges + 1] = Range.from_lua(range.first, range.last)
     end

--- a/lua/tirenvi/parser/vim_parser.lua
+++ b/lua/tirenvi/parser/vim_parser.lua
@@ -81,7 +81,7 @@ end
 ---@param req Request
 ---@param range3 Range3|nil
 ---@return Document
-function M.parse(ctx, req, range3)
+function M.parse_text_driven(ctx, req, range3)
 	local records = Record.from_tir_vim(req.lines)
 	local allow_plain = Context.is_allow_plain(ctx)
 	promote_empty_lines(records, req, allow_plain, range3)
@@ -94,7 +94,7 @@ end
 ---@param ctx Context
 ---@param req Request
 ---@return Document
-function M.parse_format(ctx, req)
+function M.parse_attr_driven(ctx, req)
 	local records = Record.from_tir_vim(req.lines)
 	--local attr = Attrs.slice(req.attrs, req.range) TODO
 	local vim_doc = Document.new_vim_doc(records, Context.is_allow_plain(ctx), req.attrs)

--- a/lua/tirenvi/types.lua
+++ b/lua/tirenvi/types.lua
@@ -1,5 +1,3 @@
----@meta
-
 ---@alias Ndjson Attr_file|Record
 
 ---@class Rect

--- a/lua/tirenvi/util/range.lua
+++ b/lua/tirenvi/util/range.lua
@@ -5,6 +5,7 @@
 local log = require("tirenvi.util.log")
 
 local M   = {}
+
 local api = vim.api
 
 ---@param first integer
@@ -45,8 +46,9 @@ end
 -- Public API
 -----------------------------------------------------------------------
 
-function M:__tostring()
-    return "range" .. M.short(self)
+---@return Range
+function M:get_range()
+    return self.range or self
 end
 
 ---@param first0 integer
@@ -156,6 +158,39 @@ function M:shift(first)
     local count = self.last - self.first + 1
     self.first = first
     self.last = first + count - 1
+end
+
+---@generic T
+---@param items T[]
+---@param range Range
+---@return T[]
+---@return T[]
+---@return T[]
+function M.split(items, range)
+    local range1 = M.from_lua(1, range.first - 1)
+    local range2 = M.from_lua(range.last + 1, math.huge)
+    return M.slice(items, range1), M.slice(items, range), M.slice(items, range2)
+end
+
+---@generic T
+---@param items T[]
+---@param range Range
+---@return T[]
+function M.slice(items, range)
+    local new_items = {}
+    if M.is_empty(range) then
+        return new_items
+    end
+    for _, item in ipairs(items) do
+        if M.intersect(M.get_range(item), range) then
+            local new_item = vim.deepcopy(item)
+            local item_range = M.get_range(new_item)
+            item_range.first = math.max(item_range.first, range.first)
+            item_range.last = math.min(item_range.last, range.last)
+            new_items[#new_items + 1] = new_item
+        end
+    end
+    return new_items
 end
 
 return M

--- a/lua/tirenvi/util/range3.lua
+++ b/lua/tirenvi/util/range3.lua
@@ -3,7 +3,6 @@
 ---@field last integer
 ---@field new_last integer
 local Range3 = {}
-Range3.__index = Range3
 
 local Range = require("tirenvi.util.range")
 
@@ -65,11 +64,11 @@ end
 ---@param new_last integer -- 1-based
 ---@return Range3
 function Range3.new(first, last, new_last)
-    return setmetatable({
+    return {
         first = first,
         last = last,
         new_last = new_last,
-    }, Range3)
+    }
 end
 
 ---@return string

--- a/tests/cases/ut/state/debug/run.vim
+++ b/tests/cases/ut/state/debug/run.vim
@@ -25,7 +25,7 @@ lua << EOF
 	local ctx =  Context.from_buf(bufnr)
   reader.read(ctx, req_r)
   log.watch("ATTR", Attrs.debug_attrs(req_r.attrs, "UPDATE CHACHED ATTRS:")) 
-  local vim_doc = vim_parser.parse(ctx, req_r, range3)
+  local vim_doc = vim_parser.parse_text_driven(ctx, req_r, range3)
   log.watch("ATTR", Document.debug_attrs(vim_doc, "1DOC ATTR:"))
 EOF
 


### PR DESCRIPTION
## Summary

Unify range slicing logic shared by `Range[]` and `Attr[]`.

### Changes

* Added generic range access utility:

  * `Range.get_range(item)`
* Shared slice implementation for:

  * `Range[]`
  * `Attr[]`
* Removed need for metatable-based method dispatch
* Kept data structures serializable and deepcopy-safe

### Motivation

Tirenvi frequently stores internal state in:

* buffer-local variables
* extmarks
* serialized cache structures

Metatable methods may be lost during serialization or msgpack conversion.

This change keeps range-related objects as plain Lua tables while still allowing shared range operations.
