### PR TITLE
support opening files in buf_doc format

### DIFF
--- a/lua/tirenvi/app/pipeline.lua
+++ b/lua/tirenvi/app/pipeline.lua
@@ -35,9 +35,6 @@ local api = vim.api
 ---@param req_r Request
 ---@return Document
 local function flat_to_doc(ctx, req_r)
-    reader.read(ctx, req_r)
-    log.watch("ATTR", Attrs.debug_attrs(req_r.attrs, "CHACHED ATTRS:"))
-    util.ensure_no_reserved_marks(req_r.lines)
     local doc = flat_parser.parse(ctx, req_r)
     log.watch("ATTR", Document.debug_attrs(doc, "1DOC ATTR:"))
     Document.apply_attrs_by_id(doc, req_r.attrs)
@@ -48,12 +45,9 @@ end
 ---@param ctx Context
 ---@param req_r Request
 ---@param range3 Range3|nil
----@return Document|nil
+---@return Document
 local function buf_to_bdoc_text_driven(ctx, req_r, range3)
     reader.read(ctx, req_r)
-    if not Attrs.has_range(req_r.attrs) then
-        return nil
-    end
     log.watch("ATTR", Attrs.debug_attrs(req_r.attrs, "CHACHED ATTRS:"))
     req_r.attrs = Attrs.adjust(req_r.attrs or {}, range3)
     if range3 then log.watch("ATTR", Attrs.debug_attrs(req_r.attrs, "0UPDATE CHACHED:")) end
@@ -78,12 +72,9 @@ end
 
 ---@param ctx Context
 ---@param req_r Request
----@return Document|nil
+---@return Document
 local function buf_to_doc_text_driven(ctx, req_r)
     local buf_doc = buf_to_bdoc_text_driven(ctx, req_r)
-    if not buf_doc then
-        return nil
-    end
     Document.apply_cached_attr(buf_doc, req_r.attrs)
     log.watch("ATTR", Document.debug_attrs(buf_doc, "4CACHED:"))
     return Document.from_buf_doc(buf_doc)
@@ -162,7 +153,7 @@ end
 local function reconcile_attrs(ctx, range3)
     local req_r = Request.from_range(Range3.get_new_range(range3))
     local buf_doc = buf_to_bdoc_text_driven(ctx, req_r, range3)
-    if not buf_doc then
+    if not Attrs.has_range(req_r.attrs) then
         return nil
     end
     Document.inherit_neighbor_attr(buf_doc, req_r.attrs, range3)
@@ -221,7 +212,6 @@ local function repair_request(ctx, range3)
     if not buf_state.is_repair(ctx, range3) then
         return
     end
-    local bufnr = ctx.bufnr
     schedule_new_range(ctx)
 end
 
@@ -266,11 +256,19 @@ end
 ---@return nil
 function M.from_flat(ctx, no_undo)
     local req_r = Request.from_range(Range.WHOLE)
-    local flat_doc = flat_to_doc(ctx, req_r)
-    Document.set_auto_attr(flat_doc)
-    log.watch("ATTR", Document.debug_attrs(flat_doc, "5AUTO ATTR:"))
-    local buf_doc = Document.to_vim(flat_doc)
-    doc_to_vim(ctx, req_r, buf_doc, no_undo)
+    reader.read(ctx, req_r)
+    log.watch("ATTR", Attrs.debug_attrs(req_r.attrs, "CHACHED ATTRS:"))
+    if util.ensure_no_reserved_marks(req_r.lines) then
+        local flat_doc = flat_to_doc(ctx, req_r)
+        Document.set_auto_attr(flat_doc)
+        log.watch("ATTR", Document.debug_attrs(flat_doc, "5AUTO ATTR:"))
+        local buf_doc = Document.to_vim(flat_doc)
+        doc_to_vim(ctx, req_r, buf_doc, no_undo)
+    else
+        local buf_doc = buf_to_doc_text_driven(ctx, req_r)
+        local attrs = Blocks.collect_attrs(buf_doc.blocks)
+        attr_store.write(ctx, attrs)
+    end
 end
 
 ---@param ctx Context

--- a/lua/tirenvi/core/attrs.lua
+++ b/lua/tirenvi/core/attrs.lua
@@ -57,6 +57,9 @@ local current_index = 1
 ---@param irow integer
 ---@return integer|nil
 local function get_index(self, irow)
+    if not self or #self == 0 then
+        return nil
+    end
     if current_index > #self then
         current_index = 1
     end
@@ -193,6 +196,9 @@ end
 ---@param irow integer
 ---@return Attr|nil
 function M:get(irow)
+    if not M.has_range(self) then
+        return nil
+    end
     return self[get_index(self, irow)]
 end
 

--- a/lua/tirenvi/core/document.lua
+++ b/lua/tirenvi/core/document.lua
@@ -155,7 +155,7 @@ end
 ---@return Attr[]
 function M:replace_attrs(range, chached_attrs)
     local doc_attrs = Blocks.collect_attrs(self.blocks)
-    if not chached_attrs or Range.is_whole(range) then
+    if not chached_attrs or not Attrs.has_range(chached_attrs) or Range.is_whole(range) then
         return doc_attrs
     end
     return Attrs.replace_attrs(chached_attrs, range, doc_attrs)

--- a/lua/tirenvi/init.lua
+++ b/lua/tirenvi/init.lua
@@ -203,7 +203,9 @@ function M.on_filetype(ctx)
 	if old_filetype and old_filetype == new_filetype then
 		return ctx
 	end
-	pipeline.to_flat(ctx)
+	if old_filetype then
+		pipeline.to_flat(ctx)
+	end
 	buffer.set(ctx.bufnr, buffer.IKEY.FILETYPE, new_filetype)
 	attr_store.write(ctx, nil)
 	ctx = Context.from_buf(ctx.bufnr)

--- a/lua/tirenvi/parser/buf_parser.lua
+++ b/lua/tirenvi/parser/buf_parser.lua
@@ -70,6 +70,9 @@ local function promote_empty_lines(records, req, allow_plain, range3)
 	if not range3 then
 		return records
 	end
+	if not Attrs.has_range(req.attrs) then
+		return records
+	end
 	if allow_plain then
 		return promote_empty_lines_gfm(records, req, range3)
 	else

--- a/lua/tirenvi/util/util.lua
+++ b/lua/tirenvi/util/util.lua
@@ -10,6 +10,7 @@
 
 local config = require("tirenvi.config")
 local errors = require("tirenvi.util.errors")
+local notify = require("tirenvi.util.notify")
 local log = require("tirenvi.util.log")
 
 
@@ -94,12 +95,15 @@ function M.extend(array1, array2)
 end
 
 ---@param fl_lines string[]
----@return nil
+---@return boolean
 function M.ensure_no_reserved_marks(fl_lines)
 	local found = find_reserved_marks(fl_lines)
 	if #found > 0 then
-		error(errors.new_domain_error(errors.err_no_usable_characters(found)))
+		--error(errors.new_domain_error(errors.err_no_usable_characters(found)))
+		notify.error(errors.err_no_usable_characters(found))
+		return false
 	end
+	return true
 end
 
 ---@param line string


### PR DESCRIPTION
This change adds support for opening files in buf_doc format.

Previously, tirenvi assumed only flat/buffer text style input in some code paths.
Now buf_doc structured files can also be loaded correctly, improving compatibility between internal document representations and persisted data.

This also prepares the codebase for future document-oriented features and refactoring.