### PR TITLE
feat: allow fractional values for fit pages

### DIFF
--- a/lua/tirenvi/width/layout.lua
+++ b/lua/tirenvi/width/layout.lua
@@ -113,8 +113,8 @@ end
 ---@param tirdoc Document
 ---@param width_mode WidthModeState
 local function fit(tirdoc, width_mode)
-    local pages = width_mode.pages or 1
-    local width = width_mode.width or buffer.get_win_width()
+    local pages = width_mode.number[1] or 1
+    local width = width_mode.number[2] or buffer.get_win_width()
     local win_width = pages * width
     Document.set_max_attr(tirdoc)
     for _, block in ipairs(tirdoc.blocks) do

--- a/lua/tirenvi/width/op.lua
+++ b/lua/tirenvi/width/op.lua
@@ -1,13 +1,13 @@
 ---@class WidthOp
 ---@field opts {kind:string, mode:string|nil, repeatable:boolean|nil}
 ---@field args string
----@field count integer|nil
----@field width integer|nil
-local WidthOp   = {}
-WidthOp.__index = WidthOp
+---@field number number[]
+local WidthOp        = {}
+WidthOp.__index      = WidthOp
 
-local Cell      = require("tirenvi.core.cell")
-local log       = require("tirenvi.util.log")
+local Cell           = require("tirenvi.core.cell")
+local WidthModeState = require("tirenvi.width.state")
+local log            = require("tirenvi.util.log")
 
 -- constants / defaults
 
@@ -19,7 +19,7 @@ local log       = require("tirenvi.util.log")
 -- Public API
 -----------------------------------------------------------------------
 
-local map       = {
+local map            = {
     ["="] = { kind = "set", mode = "fix", repeatable = true },
     ["+"] = { kind = "add", mode = "fix", repeatable = true },
     ["-"] = { kind = "sub", mode = "fix", repeatable = true },
@@ -48,14 +48,15 @@ end
 local function try_new(opts)
     local self = setmetatable({}, WidthOp)
     self.args = opts.args
+    self.number = {}
     local token, count_str = opts.args:match("^width%s*([=%+%-])(.*)")
     if token then
-        self.count = get_int(count_str)
-        self.width = nil
+        self.number[1] = get_int(count_str)
     else
         token = opts.fargs[2]
-        self.count = get_int(opts.fargs[3])
-        self.width = get_int(opts.fargs[4])
+        for index = 3, #opts.args do
+            self.number[#self.number + 1] = get_int(opts.fargs[index])
+        end
     end
     self.opts = map[token]
     return self
@@ -79,17 +80,20 @@ function WidthOp:to_cmd()
     end
 end
 
+---@param self WidthOp
 function WidthOp:to_string()
-    return string.format("WidthOp %s[%s,%s] %s", self.opts.kind, self.count or "nil", self.width or "nil", self:to_cmd())
+    return string.format("WidthOp %s[%s,%s] %s",
+        self.opts.kind, self.number[1] or "nil", self.number[2] or "nil", self:to_cmd())
 end
 
+---@param self WidthOp
 ---@param current integer
 ---@return integer
 function WidthOp:apply(current)
     local kind = self.opts.kind
-    local count = math.max(self.count or 1, 1)
+    local count = math.max(self.number[1] or 1, 1)
     if kind == "set" then
-        if not self.count or count <= 1 then
+        if not self.number[1] or count <= 1 then
             return 0
         else
             return math.max(count, Cell.MIN_WIDTH)
@@ -103,13 +107,10 @@ function WidthOp:apply(current)
     end
 end
 
+---@param self WidthOp
+---@return WidthModeState
 function WidthOp:get_state()
-    local state = { mode = self.opts.mode }
-    if self.opts.kind == "fit" then
-        state.pages = self.count
-        state.width = self.width
-    end
-    return state
+    return WidthModeState.new(self.opts.mode, self.number)
 end
 
 return WidthOp

--- a/lua/tirenvi/width/state.lua
+++ b/lua/tirenvi/width/state.lua
@@ -1,7 +1,6 @@
 ---@class WidthModeState
 ---@field mode '"fit"'|'"max"'|'"auto"'|'"fix"'
----@field pages? integer
----@field width? integer
+---@field number number[]
 
 local log = require("tirenvi.util.log")
 
@@ -18,12 +17,13 @@ local M   = {}
 -----------------------------------------------------------------------
 
 ---@param mode WidthMode
----@param pages integer|nil
----@param width integer|nil
+---@param number number[]|nil
 ---@return WidthModeState
-function M.new(mode, pages, width)
+function M.new(mode, number)
     assert(mode == "auto" or mode == "fit" or mode == "max" or mode == "fix")
-    return { mode = mode, pages = pages, width = width }
+    local self = { mode = mode }
+    self.number = number or {}
+    return self
 end
 
 return M

--- a/tests/cases/width/mode/out-expected.txt
+++ b/tests/cases/width/mode/out-expected.txt
@@ -1,18 +1,18 @@
 === MESSAGE ===
-init {'mode': 'fix'} {'mode': 'fix'}
--> fix {'mode': 'fix'} {'mode': 'fix'}
--> max {'mode': 'fix'} {'mode': 'max'}
--> fit 3 {'mode': 'max'} {'pages': 3, 'mode': 'fit'}
--> fix 5 {'pages': 3, 'mode': 'fit'} {'mode': 'fix'}
-toggle {'mode': 'fix'} {'mode': 'max'}
-toggle {'mode': 'fix'} {'mode': 'fix'}
-toggle {'mode': 'fix'} {'mode': 'max'}
-toggle {'mode': 'fix'} {'mode': 'fix'}
--> fit 99 {'mode': 'fix'} {'pages': 99, 'mode': 'fit'}
+init {'number': [], 'mode': 'fix'} {'number': [], 'mode': 'fix'}
+-> fix {'number': [], 'mode': 'fix'} {'number': [], 'mode': 'fix'}
+-> max {'number': [], 'mode': 'fix'} {'number': [], 'mode': 'max'}
+-> fit 3 {'number': [], 'mode': 'max'} {'number': [3], 'mode': 'fit'}
+-> fix 5 {'number': [3], 'mode': 'fit'} {'number': [5], 'mode': 'fix'}
+toggle {'number': [5], 'mode': 'fix'} {'number': [], 'mode': 'max'}
+toggle {'number': [5], 'mode': 'fix'} {'number': [5], 'mode': 'fix'}
+toggle {'number': [5], 'mode': 'fix'} {'number': [], 'mode': 'max'}
+toggle {'number': [5], 'mode': 'fix'} {'number': [5], 'mode': 'fix'}
+-> fit 99 {'number': [5], 'mode': 'fix'} {'number': [99], 'mode': 'fit'}
 tirenvi: install 'tpope/vim-repeat' to enable '.' repeat
--> set {'pages': 99, 'mode': 'fit'} {'mode': 'fix'}
--> set {'mode': 'fix'} {'mode': 'fix'}
--> auto {'mode': 'fix'} {'mode': 'auto'}
+-> set {'number': [99], 'mode': 'fit'} {'number': [], 'mode': 'fix'}
+-> set {'number': [], 'mode': 'fix'} {'number': [], 'mode': 'fix'}
+-> auto {'number': [], 'mode': 'fix'} {'number': [], 'mode': 'auto'}
 
 === DISPLAY ===
 gfm

--- a/tests/cases/width/mode2/out-expected.txt
+++ b/tests/cases/width/mode2/out-expected.txt
@@ -1,16 +1,16 @@
 === MESSAGE ===
-init {'mode': 'fix'} {'mode': 'fix'}
+init {'number': [], 'mode': 'fix'} {'number': [], 'mode': 'fix'}
 {'columns': [{'fix_width': 5, 'width': 5}, {'fix_width': 3, 'width': 3}, {'fix_width': 11, 'width': 11}], 'range': {'first': 3, 'last': 8}}
--> fix {'mode': 'fix'} {'mode': 'fix'}
+-> fix {'number': [], 'mode': 'fix'} {'number': [], 'mode': 'fix'}
 {'columns': [{'fix_width': 5, 'width': 5}, {'fix_width': 3, 'width': 3}, {'fix_width': 11, 'width': 11}], 'range': {'first': 3, 'last': 8}}
--> auto {'mode': 'fix'} {'mode': 'auto'}
+-> auto {'number': [], 'mode': 'fix'} {'number': [], 'mode': 'auto'}
 {'columns': [{'fix_width': 5, 'width': 7}, {'fix_width': 3, 'width': 4}, {'fix_width': 11, 'width': 15}], 'range': {'first': 3, 'last': 8}}
 tirenvi: install 'tpope/vim-repeat' to enable '.' repeat
-widt=10 {'mode': 'auto'} {'mode': 'fix'}
+widt=10 {'number': [], 'mode': 'auto'} {'number': [10], 'mode': 'fix'}
 {'columns': [{'fix_width': 10, 'width': 10}, {'fix_width': 4, 'width': 4}, {'fix_width': 15, 'width': 15}], 'range': {'first': 3, 'last': 8}}
-row:col=2:3 {'mode': 'fix'} {'mode': 'auto'}
+row:col=2:3 {'number': [10], 'mode': 'fix'} {'number': [], 'mode': 'auto'}
 {'columns': [{'fix_width': 10, 'width': 59}, {'fix_width': 4, 'width': 4}, {'fix_width': 15, 'width': 12}], 'range': {'first': 3, 'last': 8}}
-row:col=2:3 {'mode': 'fix'} {'mode': 'auto'}
+row:col=2:3 {'number': [10], 'mode': 'fix'} {'number': [], 'mode': 'auto'}
 {'columns': [{'fix_width': 10, 'width': 66}, {'fix_width': 4, 'width': 2}, {'fix_width': 15, 'width': 8}], 'range': {'first': 3, 'last': 12}}
 
 === DISPLAY ===


### PR DESCRIPTION
## Summary

Allow fractional values for `fit` pages.

Previously, the `pages` argument accepted only integer values:

```vim
:Tir width fit 1
:Tir width fit 2
````

This change allows fractional page widths as well:

```vim
:Tir width fit 0.5
:Tir width fit 1.5
```

The target table width is calculated as:

target_width = pages × window_width

## Motivation

When editing wide tables, integer page counts were sometimes too coarse.

Fractional values provide finer control over the target width while preserving the existing fit-width behavior.

## Examples

* `:Tir width fit` → 1.0 page (default)
* `:Tir width fit 0.5` → half window width
* `:Tir width fit 1.5` → one and a half window widths
* `:Tir width fit 2` → two window widths

## Compatibility

Existing integer values continue to work unchanged.
