### PR TITLE
Feat/log weighted fit

### DIFF
--- a/lua/tirenvi/width/layout.lua
+++ b/lua/tirenvi/width/layout.lua
@@ -56,17 +56,17 @@ local function max(tirdoc)
 end
 
 ---@param block Block
----@param win_width integer
+---@param max_size integer
 ---@return integer
-local function get_size(block, win_width)
+local function get_size(block, max_size)
     local columns = block.attr.columns
     local ncol = columns and #columns or #block.records
-    return win_width - ncol - 1
+    return max_size - ncol - 1
 end
 
 ---@param block Block
----@param win_width integer
-local function fit_auto_block(block, win_width)
+---@param max_size integer
+local function fit_auto_block(block, max_size)
     local total = 0
     local logws = {}
     for _, column in ipairs(block.attr.columns) do
@@ -76,7 +76,7 @@ local function fit_auto_block(block, win_width)
         total = total + logw
     end
     local columns = block.attr.columns
-    local size = get_size(block, win_width)
+    local size = get_size(block, max_size)
     for icol = 1, #columns do
         columns[icol].width = math.max(math.ceil(size * logws[icol] / total), Cell.MIN_WIDTH)
     end
@@ -99,11 +99,11 @@ local function shrink_to_fit(attr, size)
 end
 
 ---@param block Block
----@param win_width integer
-local function fit_block(block, win_width)
+---@param max_size integer
+local function fit_block(block, max_size)
     local total = Attr.get_total_width(block.attr)
     local columns = block.attr.columns
-    local size = get_size(block, win_width)
+    local size = get_size(block, max_size)
     for _, column in ipairs(columns or {}) do
         column.width = math.max(math.ceil(size * column.width / total), Cell.MIN_WIDTH)
     end
@@ -115,11 +115,11 @@ end
 local function fit(tirdoc, width_mode)
     local pages = width_mode.number[1] or 1
     local width = width_mode.number[2] or buffer.get_win_width()
-    local win_width = pages * width
+    local max_size = pages * width
     Document.set_max_attr(tirdoc)
     for _, block in ipairs(tirdoc.blocks) do
         if block.kind == "grid" then
-            fit_block(block, win_width)
+            fit_block(block, max_size)
             log.watch("ATTR", Document.debug_attrs(tirdoc, "[88]MODE"))
         end
     end
@@ -135,47 +135,47 @@ end
 
 ---@param column Attr_column
 ---@param max Attr_column
----@param win_width integer
-local function auto_expand(column, max, win_width)
+---@param max_size integer
+local function auto_expand(column, max, max_size)
     local width = math.ceil(math.sqrt(max.width * 3 / 2))
     if width <= column.width then
         return
     end
-    column.width = math.min(width, math.floor(win_width / 4))
+    column.width = math.min(width, math.floor(max_size / 4))
 end
 
 ---@param column Attr_column
 ---@param max Attr_column
----@param win_width integer
+---@param max_size integer
 ---@return boolean
-local function auto_attr(column, max, win_width)
+local function auto_attr(column, max, max_size)
     if max.width < column.width then
         auto_shrink(column, max)
         return false
     else
-        auto_expand(column, max, win_width)
+        auto_expand(column, max, max_size)
         return true
     end
 end
 
 ---@param block Block
----@param win_width integer
-local function auto_block(block, win_width)
+---@param max_size integer
+local function auto_block(block, max_size)
     local max_columns = vim.deepcopy(block.attr.columns)
-    fit_auto_block(block, win_width)
+    fit_auto_block(block, max_size)
     local is_wrap = false
     for icol = 1, #max_columns do
-        is_wrap = is_wrap or auto_attr(block.attr.columns[icol], max_columns[icol], win_width)
+        is_wrap = is_wrap or auto_attr(block.attr.columns[icol], max_columns[icol], max_size)
     end
 end
 
 ---@param tirdoc Document
 local function auto(tirdoc)
     Document.set_max_attr(tirdoc)
-    local win_width = buffer.get_win_width()
+    local max_size = buffer.get_win_width()
     for _, block in ipairs(tirdoc.blocks) do
         if block.kind == "grid" then
-            auto_block(block, win_width)
+            auto_block(block, max_size)
         end
     end
 end

--- a/lua/tirenvi/width/layout.lua
+++ b/lua/tirenvi/width/layout.lua
@@ -1,11 +1,10 @@
-local Document    = require("tirenvi.core.document")
-local Cell        = require("tirenvi.core.cell")
-local Attr        = require("tirenvi.core.attr")
-local buffer      = require("tirenvi.io.buffer")
-local width_state = require("tirenvi.width.state")
-local log         = require("tirenvi.util.log")
+local Document = require("tirenvi.core.document")
+local Cell     = require("tirenvi.core.cell")
+local Attr     = require("tirenvi.core.attr")
+local buffer   = require("tirenvi.io.buffer")
+local log      = require("tirenvi.util.log")
 
-local M           = {}
+local M        = {}
 
 -- constants / defaults
 
@@ -98,16 +97,40 @@ local function shrink_to_fit(attr, size)
     end
 end
 
+---@param columns Attr_column[]
+local function set_mini_width(columns)
+    for _, column in ipairs(columns) do
+        column.width = Cell.MIN_WIDTH
+    end
+end
+
+---@param columns Attr_column[]
+---@param extra_space integer
+local function distribute_log_width(columns, extra_space)
+    local total = 0
+    local logws = {}
+    for _, column in ipairs(columns) do
+        local logw = math.log(column.width)
+        logws[#logws + 1] = logw
+        total = total + logw
+    end
+    for icol = 1, #columns do
+        columns[icol].width = Cell.MIN_WIDTH + math.ceil(extra_space * logws[icol] / total)
+    end
+end
+
 ---@param block Block
 ---@param max_size integer
 local function fit_block(block, max_size)
-    local total = Attr.get_total_width(block.attr)
-    local columns = block.attr.columns
+    local columns = block.attr.columns or {}
     local size = get_size(block, max_size)
-    for _, column in ipairs(columns or {}) do
-        column.width = math.max(math.ceil(size * column.width / total), Cell.MIN_WIDTH)
+    local extra_space = size - #columns * Cell.MIN_WIDTH
+    if extra_space <= 0 then
+        set_mini_width(columns)
+    else
+        distribute_log_width(columns, extra_space)
+        shrink_to_fit(block.attr, size)
     end
-    shrink_to_fit(block.attr, size)
 end
 
 ---@param tirdoc Document

--- a/tests/cases/width/mode2/out-expected.txt
+++ b/tests/cases/width/mode2/out-expected.txt
@@ -8,9 +8,11 @@ init {'number': [], 'mode': 'fix'} {'number': [], 'mode': 'fix'}
 tirenvi: install 'tpope/vim-repeat' to enable '.' repeat
 widt=10 {'number': [], 'mode': 'auto'} {'number': [10], 'mode': 'fix'}
 {'columns': [{'fix_width': 10, 'width': 10}, {'fix_width': 4, 'width': 4}, {'fix_width': 15, 'width': 15}], 'range': {'first': 3, 'last': 8}}
-row:col=2:3 {'number': [10], 'mode': 'fix'} {'number': [], 'mode': 'auto'}
+fit 1 10 {'number': [10], 'mode': 'fix'} {'number': [1, 10], 'mode': 'fit'}
+{'columns': [{'fix_width': 10, 'width': 2}, {'fix_width': 4, 'width': 2}, {'fix_width': 15, 'width': 2}], 'range': {'first': 3, 'last': 21}}
+row:col=2:3 {'number': [1, 10], 'mode': 'fit'} {'number': [], 'mode': 'auto'}
 {'columns': [{'fix_width': 10, 'width': 59}, {'fix_width': 4, 'width': 4}, {'fix_width': 15, 'width': 12}], 'range': {'first': 3, 'last': 8}}
-row:col=2:3 {'number': [10], 'mode': 'fix'} {'number': [], 'mode': 'auto'}
+row:col=2:3 {'number': [1, 10], 'mode': 'fit'} {'number': [], 'mode': 'auto'}
 {'columns': [{'fix_width': 10, 'width': 66}, {'fix_width': 4, 'width': 2}, {'fix_width': 15, 'width': 8}], 'range': {'first': 3, 'last': 12}}
 
 === DISPLAY ===

--- a/tests/cases/width/mode2/run.vim
+++ b/tests/cases/width/mode2/run.vim
@@ -17,6 +17,10 @@ Tir width=10
 echomsg "widt=10" b:tirenvi.prev_width_mode b:tirenvi.width_mode
 echomsg b:tirenvi.attrs[1]
 sleep 1m
+Tir width fit 1 10
+echomsg "fit 1 10" b:tirenvi.prev_width_mode b:tirenvi.width_mode
+echomsg b:tirenvi.attrs[1]
+sleep 1m
 Tir width auto
 execute "normal! 6G050aG\<Esc>"
 sleep 1m


### PR DESCRIPTION
## Summary

Improve width allocation in `fit` mode by using logarithmic weighting instead of linear weighting based on natural column widths.

### Changes

* Replace linear width distribution with logarithmic weighting
* Reduce the influence of extremely wide columns
* Prevent a single column from consuming most of the available width
* Improve visibility of narrow and medium-width columns in wide tables

### Motivation

The previous algorithm distributed extra width proportionally to each column's natural width. As a result, tables containing one very wide column often allocated most of the available space to that column, leaving other columns close to the minimum width.

Using logarithmic weighting produces a more balanced layout while still giving wider columns additional space. This also makes the algorithm less sensitive to outlier cells that are not currently visible on screen.
