### PR TITLE
refactor: use display columns as the primary cursor coordinate

### DIFF
--- a/lua/tirenvi/app/pipeline.lua
+++ b/lua/tirenvi/app/pipeline.lua
@@ -221,7 +221,7 @@ local function change_wrap_width(ctx, width_op)
     log.assert(#bufdoc.blocks == 1, "only one block")
     local attr = bufdoc.blocks[1].attr
     if Attr.is_plain(attr) then return end
-    local column = Attr.get(attr, width_op.cur_col)
+    local column = Attr.get(attr, width_op.disp_col)
     column.width = width_op:apply(column.width)
     attr.fit_span = Attr.get_fit_span(attr)
     attr.wrap_mode = "wrap_width"
@@ -311,7 +311,7 @@ end
 ---@param width_op WidthOp
 local function width_info(ctx, width_op)
     local attrs = buffer.get(ctx.bufnr, buffer.IKEY.ATTRS)
-    local pos = Attrs.to_logical(attrs, width_op.cur_row, width_op.cur_col)
+    local pos = Attrs.to_logical(attrs, width_op.cur_row, width_op.disp_col)
     local attr = attrs[pos.iblock]
     if Attr.is_plain(attr) then
         print("kind=plain")

--- a/lua/tirenvi/editor/debug.lua
+++ b/lua/tirenvi/editor/debug.lua
@@ -59,10 +59,11 @@ local function get_info()
     if not info.attrs then
         info.attrs = {}
     end
-    local cur_row, _, char_col = buffer.get_cursor_char_pos(ctx)
+    local cur_row, _, char_col, disp_col = buffer.get_cursor_char_pos(ctx)
     info.pos = Attrs.to_logical(info.attrs, cur_row, char_col)
     info.line = buffer.get_line(ctx.bufnr, cur_row)
     info.char = vim.fn.strcharpart(info.line, char_col - 1, 1)
+    info.disp = disp_col
     return info
 end
 

--- a/lua/tirenvi/io/buffer.lua
+++ b/lua/tirenvi/io/buffer.lua
@@ -313,7 +313,7 @@ end
 ---@return integer
 function M.get_cursor_byte_pos(ctx)
 	local irow, byte_col0 = unpack(api.nvim_win_get_cursor(ctx.winid))
-	local maxrow = vim.api.nvim_buf_line_count(ctx.bufnr)
+	local maxrow = api.nvim_buf_line_count(ctx.bufnr)
 	irow = util.trim(irow, 1, maxrow)
 	local line = M.get_line(ctx.bufnr, irow)
 	byte_col0 = util.trim(byte_col0, 0, #line - 1)
@@ -333,6 +333,7 @@ function M.get_cursor_char_pos(ctx)
 	local byte_col0 = byte_col1 - 1
 	local char_col0 = vim.str_utfindex(line, byte_col0)
 	local new_byte_col = M.str_byteindex(line, "utf-32", char_col0, false) + 1
+	local disp_col = fn.strdisplaywidth(line:sub(1, char_col0 + 1))
 	return cur_row, new_byte_col, char_col0 + 1
 end
 
@@ -340,7 +341,7 @@ end
 ---@param irow integer
 ---@param icol integer
 function M.set_cursor_byte_pos(winid, irow, icol)
-	vim.api.nvim_win_set_cursor(winid, { irow, math.max(0, icol - 1) })
+	api.nvim_win_set_cursor(winid, { irow, math.max(0, icol - 1) })
 end
 
 ---@param bufnr number
@@ -353,16 +354,16 @@ function M.set_cursor_char_pos(bufnr, char_row, char_col)
 	end
 	local char_col = util.trim(char_col, 1, #line)
 	local byte_col0 = M.str_byteindex(line, "utf-32", char_col - 1, false)
-	local view = vim.fn.winsaveview()
+	local view = fn.winsaveview()
 	view.lnum = char_row
 	view.col = byte_col0
-	vim.fn.winrestview(view)
+	fn.winrestview(view)
 end
 
 ---@param winid integer
 ---@return integer
 function M.get_win_span(winid)
-	local info = vim.fn.getwininfo(winid)[1]
+	local info = fn.getwininfo(winid)[1]
 	return info.width - info.textoff
 end
 

--- a/lua/tirenvi/util/range.lua
+++ b/lua/tirenvi/util/range.lua
@@ -12,10 +12,6 @@ local api = vim.api
 ---@param last integer
 ---@return Range
 local function new(first, last)
-    if first > last then
-        -- TODO
-        -- log.error("invalid range: first(%d) > last(%d)", first, last)
-    end
     return {
         first = first,
         last = last,
@@ -63,6 +59,16 @@ end
 ---@return Range
 function M.from_lua(first, last)
     return new(first, last)
+end
+
+---@param first integer
+---@param last integer
+---@return Range
+function M.from_lua_normal(first, last)
+    return {
+        first = math.min(first, last),
+        last = math.max(first, last),
+    }
 end
 
 ---@return boolean

--- a/lua/tirenvi/width/op.lua
+++ b/lua/tirenvi/width/op.lua
@@ -17,11 +17,12 @@
 ---@field operation WidthOperation
 ---@field number integer
 ---@field cur_row integer
----@field cur_col integer
+---@field disp_col integer
 local WidthOp   = {}
 WidthOp.__index = WidthOp
 
 local Cell      = require("tirenvi.core.cell")
+local Range     = require("tirenvi.util.range")
 local log       = require("tirenvi.util.log")
 
 -- constants / defaults
@@ -38,27 +39,29 @@ local map       = {
 }
 
 ---@param opts {[string]:any}
----@return integer
----@return integer
+---@return Rect
 local function get_selection(opts)
-    local row_start = opts.line1
-    local row_end   = opts.line2
+    local row_range = Range.from_lua_normal(opts.line1, opts.line2)
     local is_block  = (vim.fn.visualmode() == "\22")
-    local col_start, col_end
+    local disp_col_start, disp_col_end
     if opts.range > 0 then
         if is_block then
-            col_start = vim.fn.virtcol("'<")
-            col_end   = vim.fn.virtcol("'>")
+            disp_col_start = vim.fn.virtcol("'<")
+            disp_col_end   = vim.fn.virtcol("'>")
         else
-            col_start = 1
-            col_end   = math.huge
+            disp_col_start = 1
+            disp_col_end   = math.huge
         end
     else
-        local col = vim.fn.virtcol(".")
-        col_start = col
-        col_end   = col
+        local col      = vim.fn.virtcol(".")
+        disp_col_start = col
+        disp_col_end   = col
     end
-    return math.min(row_start, row_end), math.min(col_start, col_end)
+    local col_range = Range.from_lua_normal(disp_col_start, disp_col_end)
+    return {
+        row = row_range,
+        col = col_range
+    }
 end
 
 ---@param str string
@@ -99,14 +102,16 @@ end
 local function try_new(opts)
     local command_name = opts.command_name
     ---@cast command_name WidthCommand
-    local cur_row, cur_col = get_selection(opts)
+    local rect = get_selection(opts)
+    local cur_row = rect.row.first
+    local disp_col = rect.col.first
     local self = setmetatable({
         args = opts.args,
         command = command_name,
         operation = "none",
         number = 0,
         cur_row = cur_row,
-        cur_col = cur_col,
+        disp_col = disp_col,
     }, WidthOp)
     if not opts.command.has_op then
         if opts.args ~= command_name then
@@ -145,7 +150,7 @@ end
 function WidthOp:to_string()
     return string.format("WidthOp %s %s (%d, %d) [%s] %s",
         self.command, self.operation or "nil",
-        self.cur_row, self.cur_col, self.number or "nil", self:to_cmd())
+        self.cur_row, self.disp_col, self.number or "nil", self:to_cmd())
 end
 
 ---@param self WidthOp

--- a/tests/cases/width/width/out-expected.txt
+++ b/tests/cases/width/width/out-expected.txt
@@ -11,47 +11,47 @@ CASE 9 // cur(1,1) b1:r1:c0 +(0,0)<->  p(1,1)* g(2,6)n[5,6] p(7,7) g(8,12)n[5,3,
 --- CASE 13: width+3 on first grid block" ---
 CASE 13 // cur(2,2) b2:r1:c1 +(0,0)<N>  p(1,1) g(2,6)w17[8*,6] p(7,7) g(8,12)n[5,3,6]
  
---- CASE 17: width-2 on second grid block, column 2" ---
-CASE 17 // cur(9,5) b4:r2:c1 +(0,3)<⠀>  p(1,1) g(2,6)w17[8,6] p(7,7) g(8,14)w17[5*,2,6]
+--- CASE 18: width-2 on second grid block, column 2" ---
+CASE 18 // cur(9,5) b4:r2:c1 +(0,3)<⠀>  p(1,1) g(2,6)w17[8,6] p(7,7) g(8,14)w17[5*,2,6]
  
---- CASE 21: width=10 on second grid block, column 2" ---
-CASE 21 // cur(9,13) b4:r2:c2 +(0,5)<⠀>  p(1,1) g(2,6)w17[8,6] p(7,7) g(8,12)w25[5,10*,6]
+--- CASE 22: width=10 on second grid block, column 2" ---
+CASE 22 // cur(9,13) b4:r2:c2 +(0,5)<⠀>  p(1,1) g(2,6)w17[8,6] p(7,7) g(8,12)w25[5,10*,6]
  
---- CASE 25: width= on second grid block, column 2" ---
-CASE 25 // cur(9,8) b4:r2:c2 +(0,0)<->  p(1,1) g(2,6)w17[8,6] p(7,7) g(8,12)w15[5,3*,6]
+--- CASE 26: width= on second grid block, column 2" ---
+CASE 26 // cur(9,8) b4:r2:c2 +(0,0)<->  p(1,1) g(2,6)w17[8,6] p(7,7) g(8,12)w15[5,3*,6]
  
---- CASE 29: width- on second grid block, column 3" ---
-CASE 29 // cur(9,12) b4:r2:c3 +(0,0)<->  p(1,1) g(2,6)w17[8,6] p(7,7) g(8,13)w17[5,3,5*]
+--- CASE 30: width- on second grid block, column 3" ---
+CASE 30 // cur(9,12) b4:r2:c3 +(0,0)<->  p(1,1) g(2,6)w17[8,6] p(7,7) g(8,13)w17[5,3,5*]
  
---- CASE 33: width on second grid block, column 3" ---
+--- CASE 34: width on second grid block, column 3" ---
 tirenvi: Invalid Tir command: width
 tirenvi: Invalid Tir command: width=x
-CASE 33 // cur(9,12) b4:r2:c3 +(0,0)<->  p(1,1) g(2,6)w17[8,6] p(7,7) g(8,13)w17[5,3,5*]
+CASE 34 // cur(9,12) b4:r2:c3 +(0,0)<->  p(1,1) g(2,6)w17[8,6] p(7,7) g(8,13)w17[5,3,5*]
  
---- CASE 41: initial cached attrs" ---
-CASE 41 // cur(1,1) b1:r1:c1 +(0,-1)<│>  g(1,7)n[2*,3,3]
+--- CASE 42: initial cached attrs" ---
+CASE 42 // cur(1,1) b1:r1:c1 +(0,-1)<│>  g(1,7)n[2*,3,3]
  
---- CASE 44: width+ on only one grid block" ---
-CASE 44 // cur(1,2) b1:r1:c1 +(0,0)<1>  g(1,7)w13[3*,3,3]
+--- CASE 45: width+ on only one grid block" ---
+CASE 45 // cur(1,2) b1:r1:c1 +(0,0)<1>  g(1,7)w13[3*,3,3]
  
---- CASE 48: width=20 on only one grid block" ---
-CASE 48 // cur(3,10) b1:r3:c3 +(0,0)<b>  g(1,7)w30[3,3,20*]
+--- CASE 49: width=20 on only one grid block" ---
+CASE 49 // cur(3,10) b1:r3:c3 +(0,0)<b>  g(1,7)w30[3,3,20*]
  
---- CASE 52: undo ---
+--- CASE 53: undo ---
 7 changes; before #2  <time>
-CASE 52 // cur(3,10) b1:r3:c3 +(0,0)<b>  g(1,7)w30[3,3,3*]
+CASE 53 // cur(3,10) b1:r3:c3 +(0,0)<b>  g(1,7)w30[3,3,3*]
  
---- CASE 56: undo #2 ---
+--- CASE 57: undo #2 ---
 7 changes; before #1  <time>
-CASE 56 // cur(1,2) b1:r1:c1 +(0,0)<1>  g(1,7)w30[2*,3,3]
+CASE 57 // cur(1,2) b1:r1:c1 +(0,0)<1>  g(1,7)w30[2*,3,3]
  
---- CASE 60: undo #3 ---
+--- CASE 61: undo #3 ---
 Already at oldest change
-CASE 60 // cur(1,2) b1:r1:c1 +(0,0)<1>  g(1,7)w30[2*,3,3]
+CASE 61 // cur(1,2) b1:r1:c1 +(0,0)<1>  g(1,7)w30[2*,3,3]
  
---- CASE 64: redo ---
+--- CASE 65: redo ---
 7 changes; after #1  <time>
-CASE 64 // cur(1,2) b1:r1:c1 +(0,0)<1>  g(1,7)w30[3*,3,3]
+CASE 65 // cur(1,2) b1:r1:c1 +(0,0)<1>  g(1,7)w30[3*,3,3]
 
 === DISPLAY ===
 │1a⠀│2 a│ 3a│

--- a/tests/cases/width/width/run.vim
+++ b/tests/cases/width/width/run.vim
@@ -11,7 +11,8 @@ CASE width+ on first plain block"
         call Tir("width+")
 
 CASE width+3 on first grid block"
-	call At(2, 1, 1)
+	call At(4, 3, 3)
+	call feedkeys("\<C-V>8k9h", 'x')
 		call Tir("width+3")
 
 CASE width-2 on second grid block, column 2"


### PR DESCRIPTION
## Summary

Use display columns (`disp`) as the primary unit for cursor coordinates throughout Tirenvi.

Previously, cursor-related code mixed byte, character, and display-column coordinates, making the implementation harder to follow and increasing the number of conversions.

This change standardizes the internal cursor representation on display columns. Conversions to and from byte offsets are now performed only when interacting with the Neovim API.

This refactoring lays the groundwork for more reliable logical cursor restoration, especially when working with wide characters and wrapped table cells.