### PR TITLE
feat: keep column position during vertical motion

### DIFF
--- a/lua/tirenvi/app/request.lua
+++ b/lua/tirenvi/app/request.lua
@@ -29,6 +29,7 @@ local M = {}
 ---@param no_undo boolean|nil
 ---@return Request
 function M.new_writer(r_req, lines, no_undo)
+    ---@type Request
     return {
         range = r_req.range,
         lines = lines,

--- a/lua/tirenvi/cursor/nvim.lua
+++ b/lua/tirenvi/cursor/nvim.lua
@@ -14,18 +14,25 @@ local b      = vim.b
 -- Private helpers
 -----------------------------------------------------------------------
 
+---@param line string
+---@param col_char integer
+---@return integer -- byte index (1-based)
+local function char_to_byte(line, col_char)
+    local nchar = vim.str_utfindex(line) + 1
+    log.assert(col_char <= nchar, "col_char(%d) <= nchar(%d) : %s", col_char, nchar, line)
+    col_char = math.min(col_char, nchar)
+    -- str_byteindex(line, "utf-32", col_char - 1, false)
+    return vim.str_byteindex(line, col_char - 1) + 1
+end
+
 ---@param cursor CursorBuf
 ---@param line string
 local function complete(cursor, line)
     cursor.line = line
-    local col_char0 = vim.str_utfindex(line, cursor.col_byte - 1)
-    local nchar = vim.str_utfindex(line)
-    log.assert(col_char0 <= nchar, "col_char0(%d) <= nchar(%d) : %s", col_char0, nchar, line)
-    col_char0 = math.min(col_char0, nchar)
-    cursor.col_char = col_char0 + 1
-    cursor.col_byte = vim.str_byteindex(line, col_char0) + 1
-    cursor.char = fn.strcharpart(line, col_char0, 1)
-    local prefix = fn.strcharpart(line, 0, col_char0)
+    cursor.col_char = vim.str_utfindex(line, cursor.col_byte - 1) + 1
+    cursor.col_byte = char_to_byte(line, cursor.col_char)
+    cursor.char = fn.strcharpart(line, cursor.col_char - 1, 1)
+    local prefix = fn.strcharpart(line, 0, cursor.col_char - 1)
     cursor.col_disp = fn.strdisplaywidth(prefix) + 1
 end
 
@@ -42,11 +49,28 @@ end
 
 ---@param row_cur integer
 ---@param col_byte integer
-local function set_cursor(row_cur, col_byte)
+local function restore_cursor(row_cur, col_byte)
     local view = fn.winsaveview()
     view.lnum = row_cur
     view.col = col_byte - 1
     fn.winrestview(view)
+end
+
+---@param col_disp integer
+---@param line string
+---@return integer
+local function disp_to_byte(line, col_disp)
+    local nchar = vim.str_utfindex(line)
+    local disp = 1
+    for ichar = 1, nchar do
+        local char = vim.fn.strcharpart(line, ichar - 1, 1)
+        local width = vim.fn.strdisplaywidth(char)
+        if col_disp < disp + width then
+            return char_to_byte(line, ichar)
+        end
+        disp = disp + width
+    end
+    return #line + 1
 end
 
 -----------------------------------------------------------------------
@@ -60,37 +84,6 @@ function M.capture(ctx)
     return get_cursor(ctx, row_cur, col_byte0 + 1)
 end
 
----@param ctx Context
-function M.reset(ctx)
-    local cursor = M.capture(ctx)
-    set_cursor(cursor.row_cur, cursor.col_byte)
-end
-
----@param ctx Context
----@param row_cur integer
----@param col_byte integer
-function M.move(ctx, row_cur, col_byte)
-    local cursor = get_cursor(ctx, row_cur, col_byte)
-    set_cursor(cursor.row_cur, cursor.col_byte)
-end
-
----@param col_disp integer
----@param line string
----@return integer
-local function disp_to_byte(line, col_disp)
-    local nchar = vim.str_utfindex(line)
-    local disp = 1
-    for ichar = 0, nchar - 1 do
-        local char = vim.fn.strcharpart(line, ichar, 1)
-        local width = vim.fn.strdisplaywidth(char)
-        if col_disp < disp + width then
-            return vim.str_byteindex(line, ichar) + 1
-        end
-        disp = disp + width
-    end
-    return #line + 1
-end
-
 ---@param line string
 ---@param row_cur integer
 ---@param col_disp integer
@@ -98,6 +91,40 @@ end
 function M.from_col_disp(line, row_cur, col_disp)
     local col_byte = disp_to_byte(line, col_disp)
     return Cursor.new(row_cur, col_byte)
+end
+
+---@param ctx Context
+function M.reset(ctx)
+    local cursor = M.capture(ctx)
+    restore_cursor(cursor.row_cur, cursor.col_byte)
+end
+
+--- Normal cursor movement.
+--- Preserves window view and preferred column.
+---@param ctx Context
+---@param row_cur integer
+---@param col_byte integer
+function M.restore_byte(ctx, row_cur, col_byte)
+    local cursor = get_cursor(ctx, row_cur, col_byte)
+    restore_cursor(cursor.row_cur, cursor.col_byte)
+end
+
+---@param ctx Context
+---@param row_cur integer
+---@param col_disp integer
+function M.restore_disp(ctx, row_cur, col_disp)
+    local line = ctx.line_provider.get_line(row_cur) or ""
+    local cursor = M.from_col_disp(line, row_cur, col_disp)
+    M.restore_byte(ctx, row_cur, cursor.col_byte)
+end
+
+--- Direct cursor update.
+--- Use for Visual/Visual Block.
+---@param ctx Context
+---@param row_cur integer
+---@param col_byte integer
+function M.move_byte(ctx, row_cur, col_byte)
+    api.nvim_win_set_cursor(ctx.winid, { row_cur, math.max(0, col_byte - 1) })
 end
 
 function M.restore()

--- a/lua/tirenvi/editor/debug.lua
+++ b/lua/tirenvi/editor/debug.lua
@@ -126,7 +126,7 @@ function M.goto(iblock, irow, icol)
     local row_cur, col_disp = Attrs.to_cursor(attrs, logical)
     local line = buffer.get_line(ctx.bufnr, row_cur) or ""
     local cursor = CursorNvim.from_col_disp(line, row_cur, col_disp)
-	buffer.set_cursor_byte_pos(ctx.winid, row_cur, cursor.col_byte)
+	CursorNvim.move_byte(ctx, row_cur, cursor.col_byte)
 end
 
 function M.show_attr_marks(ctx)

--- a/lua/tirenvi/editor/motion.lua
+++ b/lua/tirenvi/editor/motion.lua
@@ -38,7 +38,7 @@ function M.block_top()
 	local cursor  = reader.cursor(ctx)
 	local pos     = Attrs.to_logical(attrs, cursor.row_cur, cursor.col_disp)
 	local top_row = attrs[pos.iblock].range.first
-	buffer.set_cursor_char_pos(ctx.bufnr, top_row, cursor.col_char)
+	CursorNvim.restore_disp(ctx, top_row, cursor.col_disp)
 end
 
 function M.block_bottom()
@@ -47,7 +47,7 @@ function M.block_bottom()
 	local cursor     = reader.cursor(ctx)
 	local pos        = Attrs.to_logical(attrs, cursor.row_cur, cursor.col_disp)
 	local bottom_row = attrs[pos.iblock].range.last
-	buffer.set_cursor_char_pos(ctx.bufnr, bottom_row, cursor.col_char)
+	CursorNvim.restore_disp(ctx, bottom_row, cursor.col_disp)
 end
 
 return M

--- a/lua/tirenvi/editor/textobj.lua
+++ b/lua/tirenvi/editor/textobj.lua
@@ -2,6 +2,7 @@ local Context = require("tirenvi.app.context")
 local Bufline = require("tirenvi.core.bufline")
 local buf_parser = require("tirenvi.parser.buf_parser")
 local config = require("tirenvi.config")
+local CursorNvim = require("tirenvi.cursor.nvim")
 local LinProvider = require("tirenvi.io.buffer_line_provider")
 local buffer = require("tirenvi.io.buffer")
 local errors = require("tirenvi.util.errors")
@@ -25,10 +26,10 @@ local function setup_vl(is_around)
         notify.error(errors.ERR.TABLE_IS_NOT_ALIGNED)
         return
     end
-    buffer.set_cursor_byte_pos(ctx.winid, rect.row.first, rect.col.first)
+    CursorNvim.move_byte(ctx, rect.row.first, rect.col.first)
     vim.api.nvim_feedkeys(vim.keycode("<C-v>"), "n", false)
     vim.cmd("normal! o")
-    buffer.set_cursor_byte_pos(ctx.winid, rect.row.last, rect.col.last)
+    CursorNvim.move_byte(ctx, rect.row.last, rect.col.last)
 end
 
 local function setup_vil()

--- a/lua/tirenvi/io/buffer.lua
+++ b/lua/tirenvi/io/buffer.lua
@@ -75,7 +75,7 @@ local function set_cursor_pos(ctx, cursor)
 	if not cursor then
 		CursorNvim.reset(ctx)
 	elseif cursor.restore_mode == "buffer" then
-		CursorNvim.move(ctx, cursor.row_cur, cursor.col_byte)
+		CursorNvim.restore_byte(ctx, cursor.row_cur, cursor.col_byte)
 	elseif cursor.restore_mode == "logical" then
 		reset_cursor_logical(ctx, cursor)
 	else
@@ -292,43 +292,10 @@ function M.set_step(step)
 end
 
 ---@param winid integer
----@param irow integer
----@param icol integer
-function M.set_cursor_byte_pos(winid, irow, icol)
-	api.nvim_win_set_cursor(winid, { irow, math.max(0, icol - 1) })
-end
-
----@param bufnr number
----@param row_cur integer
----@param col_char integer
-function M.set_cursor_char_pos(bufnr, row_cur, col_char)
-	local line = M.get_line(bufnr, row_cur)
-	if not line then
-		return
-	end
-	local col_char = util.trim(col_char, 1, #line)
-	local col_byte0 = M.str_byteindex(line, col_char - 1)
-	local view = fn.winsaveview()
-	view.lnum = row_cur
-	view.col = col_byte0
-	fn.winrestview(view)
-end
-
----@param winid integer
 ---@return integer
 function M.get_win_span(winid)
 	local info = fn.getwininfo(winid)[1]
 	return info.width - info.textoff
-end
-
----@param chars string
----@param ichar0 integer
----@return integer -- byte index (0-based)
-function M.str_byteindex(chars, ichar0)
-	local nchar = vim.str_utfindex(chars)
-	ichar0 = math.min(ichar0, nchar)
-	return vim.str_byteindex(chars, ichar0)
-	-- str_byteindex(line, "utf-32", col_char - 1, false)
 end
 
 return M

--- a/tests/cases/motion/ftg/out-expected.txt
+++ b/tests/cases/motion/ftg/out-expected.txt
@@ -2,37 +2,37 @@
 === MESSAGE ===
  
 --- CASE 6: initial ---
-CASE 6 // cur(1,1) b1:r1:c0+0<g>  p(1,2)* g(3,8)n[5,3,11] p(9,11)
+CASE 6 // cur(3,12) b2:r1:c3+1<C>  p(1,2) g(3,8)n[5,3,11*] p(9,11)
  
---- CASE 9: block#2 bottom ---
-CASE 9 // cur(8,2) b2:r6:c1+1<C>  p(1,2) g(3,8)n[5*,3,11] p(9,11)
+--- CASE 10: block#2 bottom ---
+CASE 10 // cur(8,12) b2:r6:c3+1<名>  p(1,2) g(3,8)n[5,3,11*] p(9,11)
  
 --- CASE 14: block#2 top ---
-CASE 14 // cur(3,2) b2:r1:c1+1<名>  p(1,2) g(3,8)n[5*,3,11] p(9,11)
+CASE 14 // cur(3,12) b2:r1:c3+1<C>  p(1,2) g(3,8)n[5,3,11*] p(9,11)
  
 --- CASE 18: next cell ---
 CASE 18 // cur(3,7) b2:r1:c2+0<│>  p(1,2) g(3,8)n[5,3*,11] p(9,11)
  
---- CASE 22: next 2cell ---
-CASE 22 // cur(3,23) b2:r1:c3+11<│>  p(1,2) g(3,8)n[5,3,11*] p(9,11)
+--- CASE 23: next 2cell ---
+CASE 23 // cur(3,23) b2:r1:c3+11<│>  p(1,2) g(3,8)n[5,3,11*] p(9,11)
  
---- CASE 26: prev 2cell ---
-CASE 26 // cur(3,7) b2:r1:c2+0<│>  p(1,2) g(3,8)n[5,3*,11] p(9,11)
+--- CASE 27: prev 2cell ---
+CASE 27 // cur(3,7) b2:r1:c2+0<│>  p(1,2) g(3,8)n[5,3*,11] p(9,11)
  
---- CASE 30: next cell ---
-CASE 30 // cur(6,6) b2:r4:c1+5<⠀>  p(1,2) g(3,8)n[5*,3,11] p(9,11)
+--- CASE 31: next cell ---
+CASE 31 // cur(6,6) b2:r4:c1+5<⠀>  p(1,2) g(3,8)n[5*,3,11] p(9,11)
  
---- CASE 35: repeat 3cell ---
-CASE 35 // cur(6,22) b2:r4:c3+11<⠀>  p(1,2) g(3,8)n[5,3,11*] p(9,11)
+--- CASE 36: repeat 3cell ---
+CASE 36 // cur(6,22) b2:r4:c3+11<⠀>  p(1,2) g(3,8)n[5,3,11*] p(9,11)
  
---- CASE 39: prev cell ---
-CASE 39 // cur(6,12) b2:r4:c3+1<大>  p(1,2) g(3,8)n[5,3,11*] p(9,11)
+--- CASE 40: prev cell ---
+CASE 40 // cur(6,12) b2:r4:c3+1<大>  p(1,2) g(3,8)n[5,3,11*] p(9,11)
  
---- CASE 46: CSV bottom ---
-CASE 46 // cur(7,7) b1:r7:c2+3<⠀>  g(1,7)n[2,3*,3]
+--- CASE 47: CSV bottom ---
+CASE 47 // cur(7,7) b1:r7:c2+3<⠀>  g(1,7)n[2,3*,3]
  
---- CASE 52: CSV top ---
-CASE 52 // cur(1,7) b1:r1:c2+3<a>  g(1,7)n[2,3*,3]
+--- CASE 53: CSV top ---
+CASE 53 // cur(1,7) b1:r1:c2+3<a>  g(1,7)n[2,3*,3]
 
 === DISPLAY ===
 │1a│2 a│３a│

--- a/tests/cases/motion/ftg/run.vim
+++ b/tests/cases/motion/ftg/run.vim
@@ -4,10 +4,10 @@ source $TIRENVI_ROOT/tests/common.vim
 edit $TIRENVI_ROOT/tests/data/simple.md
 
 CASE initial
+	call At(2, 1, 3)
             lua print(Debug.layout())
 
 CASE block#2 bottom
-	call At(2, 1, 1)
         lua require('tirenvi').motion.block_bottom()
             lua print(Debug.layout())
 
@@ -16,6 +16,7 @@ CASE block#2 top
             lua print(Debug.layout())
 
 CASE next cell
+	call At(2, 1, 1)
         execute "normal! " . luaeval("require('tirenvi.editor.motion').f()")
             lua print(Debug.layout())
 

--- a/tests/cases/ut/log/cursor/out-expected.txt
+++ b/tests/cases/ut/log/cursor/out-expected.txt
@@ -1,20 +1,20 @@
---- test Buffer.set_cursor_char_pos ---
+--- test CursorNvim.restore_disp ---
 === MESSAGE ===
 irow, col_byte, col_char 
  
---- CASE 24: set (1,1) & add ABC, insert XYZ" ---
+--- CASE 25: set (1,1) & add ABC, insert XYZ" ---
 1 1 1
 1 1 1
  
---- CASE 34: set (2,5) & add 123, insert 789" ---
+--- CASE 35: set (2,5) & add 123, insert 789" ---
 2 13 5
 2 13 5
  
---- CASE 44: set (3,10) & add 甲乙, insert 丙丁" ---
+--- CASE 45: set (3,10) & add 甲乙, insert 丙丁" ---
 3 20 10
 3 20 10
  
---- CASE 54: kkjj" ---
+--- CASE 55: kkjj" ---
 silent ascii =>  <丁> 19969, Hex 4e01, Octal 47001
 3 23 11
 silent ascii =>  <か> 12363, Hex 304b, Oct 30113, Digr ka

--- a/tests/cases/ut/log/cursor/run.vim
+++ b/tests/cases/ut/log/cursor/run.vim
@@ -6,6 +6,7 @@ lua << EOF
   Context = require("tirenvi.app.context")
   Buffer = require("tirenvi.io.buffer")
   Range = require("tirenvi.util.range")
+  CursorNvim = require("tirenvi.cursor.nvim")
   local lines = {
     "1234567890",
     "あいうえおかきくけこ",
@@ -22,31 +23,31 @@ EOF
 			lua print("irow, col_byte, col_char ")
 
 CASE set (1,1) & add ABC, insert XYZ"
-	lua Buffer.set_cursor_char_pos(ctx.bufnr, 1, 1)
+	lua CursorNvim.restore_disp(ctx, 1, 1)
 			lua print_cursor(ctx)
 		normal! aABC
 		lua Buffer.clear_cache()
-	lua Buffer.set_cursor_char_pos(ctx.bufnr, 1, 1)
+	lua CursorNvim.restore_disp(ctx, 1, 1)
 			lua print_cursor(ctx)
 		normal! iXYZ
 		lua Buffer.clear_cache()
 
 CASE set (2,5) & add 123, insert 789"
-	lua Buffer.set_cursor_char_pos(ctx.bufnr, 2, 5)
+	lua CursorNvim.restore_disp(ctx, 2, 9)
 			lua print_cursor(ctx)
 		normal! a123
 		lua Buffer.clear_cache()
-	lua Buffer.set_cursor_char_pos(ctx.bufnr, 2, 5)
+	lua CursorNvim.restore_disp(ctx, 2, 9)
 			lua print_cursor(ctx)
 		normal! i789
 		lua Buffer.clear_cache()
 
 CASE set (3,10) & add 甲乙, insert 丙丁"
-	lua Buffer.set_cursor_char_pos(ctx.bufnr, 3, 10)
+	lua CursorNvim.restore_disp(ctx, 3, 15)
 			lua print_cursor(ctx)
 		normal! a甲乙
 		lua Buffer.clear_cache()
-	lua Buffer.set_cursor_char_pos(ctx.bufnr, 3, 10)
+	lua CursorNvim.restore_disp(ctx, 3, 15)
 			lua print_cursor(ctx)
 		normal! i丙丁
 		lua Buffer.clear_cache()
@@ -67,4 +68,4 @@ CASE kkjj"
       		call Dump('silent ascii')
 			lua print_cursor(ctx)
 
-call Snapshot({ 'desc': 'test Buffer.set_cursor_char_pos' })
+call Snapshot({ 'desc': 'test CursorNvim.restore_disp' })


### PR DESCRIPTION
## Summary

Keep the cursor column stable during vertical motion in Tirenvi.

### Changes

- Preserve the preferred column while moving vertically.
- Restore the cursor to the closest valid position when the target line is shorter.
- Improve consistency of cursor movement across table rows.

This makes vertical navigation behave more naturally, especially when moving through rows with different cell widths.