### PR TITLE
refactor: use polymorphic get_range() for Range and Attr

### DIFF
--- a/lua/tirenvi/core/document.lua
+++ b/lua/tirenvi/core/document.lua
@@ -45,7 +45,7 @@ local M = {}
 ---@field allow_plain boolean
 
 ---@class Attr
----@field range Range
+---@field range Range|nil
 ---@field wrap_mode WrapMode|nil
 ---@field fit_span integer
 ---@field columns Attr_column[]

--- a/lua/tirenvi/util/range.lua
+++ b/lua/tirenvi/util/range.lua
@@ -5,10 +5,11 @@ local log = require("tirenvi.util.log") -- Util
 -- =============================================================================
 
 ---@class Range
----@field first integer
----@field last integer
+---@field first integer|nil
+---@field last integer|nil
 
 local M = {}
+M.__index = M
 
 -- =============================================================================
 --#region Private
@@ -17,13 +18,14 @@ local M = {}
 ---@param last integer
 ---@return Range
 local function new(first, last)
-	return {
+	local self = setmetatable({
 		first = first,
 		last = last,
-	}
+	}, M)
+	return self
 end
 
-M.WHOLE = { first = nil, last = nil }
+M.WHOLE = setmetatable({}, M)
 
 ---@return Range[]
 local function sort(ranges)
@@ -48,9 +50,13 @@ end
 -- Public API
 
 ---@param self Range|Attr
----@return Range
+---@return Range|nil
 function M:get_range()
-	return self.range or self
+	if getmetatable(self) == M then
+		---@type Range
+		return self
+	end
+	return self.range
 end
 
 ---@param self Range
@@ -91,9 +97,6 @@ end
 ---@return boolean
 function M:intersects(target)
 	if not self or not target then
-		return false
-	end
-	if not self.last or not target.first then
 		return false
 	end
 	if self.last < target.first then

--- a/lua/tirenvi/width/request.lua
+++ b/lua/tirenvi/width/request.lua
@@ -1,9 +1,6 @@
-local fn = vim.fn -- Neovim
-
 local Cell = require("tirenvi.core.cell") -- Core
 
-local Range = require("tirenvi.util.range") -- Util
-local log = require("tirenvi.util.log")
+local log = require("tirenvi.util.log") -- Util
 
 ---@alias WidthAction
 ---| "set"


### PR DESCRIPTION
## Summary

Move the `get_range()` responsibility from the shared helper to the `Range` and `Attr` types.

### Changes

- Add `Range:get_range()` returning `self`
- Add `Attr:get_range()` returning `self.range`
- Update range utilities to call `item:get_range()`
- Remove type-specific logic from the shared helper

### Benefits

- Separates responsibilities between `Range` and `Attr`
- Eliminates the need for runtime type checks in range operations
- Makes the range API polymorphic and easier to extend
- Reduces coupling between the `Range` module and `Attr` implementation