### PR TITLE
fix: use parser availability instead of filetype

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.5.0] - 2026-07-28
+
+### Added
+
+- Implemented Tir-embedded support.
+  - Tables can now be embedded and edited inside arbitrary files such as txt, Python, and Java source files.
+- Added column width adjustment commands.
+  - `:Tir fit=n`
+  - `:Tir fit=`
+  - `:Tir fit{+|-}[n]`
+  - `:Tir wrap`
+- Changed width settings to be managed per table instead of applying to all tables in a file.
+- Added `manage_wrap` mode.
+  - Enables wrap for plain-style lines when content exceeds the window width.
+  - Disables wrap for grid-style lines to preserve table layout.
+- Improved vertical navigation behavior.
+  - Moving through rows with different cell widths now behaves more naturally.
+- Restore the cursor position after `:write` / `WritePost`.
+- Automatically install required parser packages when using lazy.nvim.
+- Added TIR (ndjson) file I/O support for debugging.
+  - `:Tir _read_tir {file}`
+  - `:Tir _write_tir {file}`
+- Added support for opening files saved in tir-buf format.
+
+### Refactoring
+
+- Reorganized internal modules.
+- Reorganized buffer-local layout state handling.
+- Rebuilt CI test cases.
+
 ## [0.4.0] - 2026-05-25
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@
 
 > Markdown & CSV table editor for Neovim — structural editing, pure text, always valid.
 
-Supports Markdown and CSV out of the box,
-and can be extended to other formats via custom parsers.
+Supports Markdown and CSV out of the box.
+
+**Edit tables anywhere** — including arbitrary text files via the Tir-embedded format.
 
 ## Markdown (GFM)
 
@@ -24,6 +25,31 @@ Raw → aligned → edit → back to raw (lossless).
 ![demo gif](./demo_csv.gif)
 
 Raw → aligned → edit → back to raw (lossless).
+
+## Embedded tables (NEW)
+
+Edit tables embedded inside source code,
+configuration files, or plain text documents
+without changing the surrounding text.
+
+For example, tirenvi can edit tables embedded in Python source code:
+
+```python
+# | Name  | City   |
+# | ----- | ------ |
+# | Alice | Tokyo  |
+# | Bob   | Osaka  |
+
+print("Hello Tir")
+```
+
+Use :Tir toggle to switch between the original text
+and the structured table view.
+
+For details about the embedded table format, see the
+[tir-embedded documentation](https://github.com/kibi2/tir-embedded).
+
+*Demo coming soon.*
 
 ## Design Philosophy
 
@@ -56,7 +82,7 @@ TIR (intermediate representation)
 tir-buf (structured buffer view)
 ```
 
-Editing happens in **tir-buf format**.
+Editing takes place **tir-buf format**.
 
 On save:
 
@@ -79,17 +105,19 @@ Edit tables directly in Vim while preserving a structured internal model.
 ## Features
 
 * Render CSV/TSV/GFM into an aligned structured view
+* Edit tables embedded in any text file (Tir-embedded)
 * Preserve original file format on save
 * Toggle raw ↔ structured view
 * Immediate or deferred structural repair
 * Dirty line tracking and highlighting
 * Multiline cell support with preserved line breaks
 * Column width control with wrapping support
+* Automatic wrap management for plain and grid views
 * Grid-aware join that preserves column structure
 * Column text objects for structural editing
 * Works with native Vim motions and operators
 * External parser architecture (extensible)
-* No learning curve
+* Uses standard Vim editing
 
 ## Structural Integrity Model
 
@@ -101,7 +129,7 @@ In deferred repair mode:
 * Dirty lines are tracked incrementally
 * Internal attrs/model state remains structurally valid
 * Buffer structure may temporarily diverge from the model
-* `:Tir repair` synchronizes the buffer with the internal model
+* `:Tir redraw` synchronizes the buffer with the internal model
 
 In immediate repair mode:
 
@@ -124,6 +152,7 @@ even if they contain temporary structural inconsistencies.
   dependencies = {
     { "kibi2/tir-csv", build = "pip install ." },
     { "kibi2/tir-gfm-lite", build = "pip install ." },
+    { "kibi2/tir-embedded", build = "pip install ." },
     { "tpope/vim-repeat" }, -- Optional: enables '.' repeat for column width operations
   },
   config = function()
@@ -132,7 +161,7 @@ even if they contain temporary structural inconsistencies.
 }
 ```
 
-The required CSV and GFM parsers are installed automatically when using lazy.nvim.
+The required parser packages are installed automatically when using lazy.nvim.
 
 ### vim-plug
 
@@ -142,6 +171,7 @@ Plug 'kibi2/tirenvi.nvim'
 " Required parsers
 Plug 'kibi2/tir-csv' { 'do': 'pip install .' }
 Plug 'kibi2/tir-gfm-lite' { 'do': 'pip install .' }
+Plug 'kibi2/tir-embedded' { 'do': 'pip install .' }
 
 " Optional: enables '.' repeat for column width operations
 Plug 'tpope/vim-repeat'
@@ -169,6 +199,9 @@ Automatically activates based on filetype (via parser_map):
 * `markdown`
 * `pukiwiki`
 
+For embedded tables, use `:Tir toggle` to switch
+between the original text and the structured table view.
+
 Custom parser mapping:
 
 ```lua
@@ -177,6 +210,7 @@ require("tirenvi").setup({
     csv = { executable = "tir-csv", required_version = "0.1.4" },
     tsv = { executable = "tir-csv", options = { "--delimiter", "\t" }, required_version = "0.1.4" },
     markdown = { executable = "tir-gfm-lite", allow_plain = true, required_version = "0.1.6" },
+    ["*"] = { executable = "tir-embedded", allow_plain = true },
     pukiwiki = { executable = "tir-pukiwiki", allow_plain = true, required_version = "0.1.1" },
   }
 })
@@ -186,13 +220,15 @@ require("tirenvi").setup({
 
 | Command                  | Description                                                         |
 | ------------------------ | ------------------------------------------------------------------- |
-| `:Tir repair`            | Repair and reformat dirty tables                                    |
+| `:Tir width{=+-}[count]` | Adjust column width by count (`=`: set, `+/-`: increment/decrement) |
+| `:Tir fit{=+-}[count]`   | Adjust table span by count (`=`: set, `+/-`: increment/decrement)   |
+| `:Tir wrap`              | Toggle nowrap ↔ wrap width mode                                     |
+| `:Tir redraw`            | Redraw and reformat dirty tables                                    |
+| `:Tir toggle`            | Toggle raw ↔ structured table view                                  |
 | `:Tir repair enable`     | Enable automatic structural repair                                  |
 | `:Tir repair disable`    | Disable automatic structural repair                                 |
 | `:Tir repair toggle`     | Toggle automatic structural repair                                  |
-| `:Tir toggle`            | Switch raw ↔ structured table view                                  |
-| `:Tir width[=+-][count]` | Adjust column width by count (`=`: set, `+/-`: increment/decrement) |
-| `:Tir redraw`            | Deprecated. Will be removed in v0.5.<br>Use `:Tir repair` instead   |
+| `:Tir repair`            | Deprecated. Will be removed in v0.6.<br>Use `:Tir redraw` instead   |
 
 All native Vim editing works.
 
@@ -201,6 +237,13 @@ All native Vim editing works.
 * Visual mode command
 
 No special editing mode.
+
+## Editing Tips
+
+* Inserting a line above the first row of a table creates a normal text line.
+* Inserting a line below the last row appends a new table row.
+* Press `D` (or `S`) at the beginning of a table row to split the table.
+* Press `D` at the beginning of the second column to clear the cell contents.
 
 ## Column Editing
 
@@ -257,25 +300,25 @@ It is a structured text editor layer.
 
 ### In Progress
 
-* Text objects (table, row, column, cell)
+* Text objects (table, row, cell)
 
 ### Planned
 
-* Column formatting presets
 * Outline mode
 
 ## Comparison
 
-| Feature | Tirenvi | csv.vim | Spreadsheet tools |
+| Feature                   | Tirenvi | csv.vim | Spreadsheet tools |
 | ------------------------- | ------- | ------- | ----------------- |
-| Native Vim editing | ✅ | ⚠️ | ❌ |
-| Always structurally valid | ✅ | ❌ | ⚠️ |
-| No file format change | ✅ | ❌ | ❌ |
-| No custom buffer type | ✅ | ❌ | ❌ |
-| Toggle raw view | ✅ | ❌ | ❌ |
-| Markdown | ✅ | ❌ | ❌ |
-| Automatic wrapping | ✅ | ❌ | ⚠️ |
-| Grid-aware join | ✅ | ❌ | ❌ |
+| Native Vim editing        | ✅       | ⚠️       | ❌                 |
+| Always structurally valid | ✅       | ❌       | ⚠️                 |
+| No file format change     | ✅       | ❌       | ❌                 |
+| No custom buffer type     | ✅       | ❌       | ❌                 |
+| Toggle raw view           | ✅       | ❌       | ❌                 |
+| Markdown                  | ✅       | ❌       | ❌                 |
+| Automatic wrapping        | ✅       | ❌       | ⚠️                 |
+| Grid-aware join           | ✅       | ❌       | ❌                 |
+| Embedded table            | ✅       | ❌       | ❌                 |
 
 Tirenvi prioritizes **structural safety with Vim purity**.
 
@@ -293,4 +336,3 @@ Please open an issue before major design proposals.
 ## License
 
 MIT License.
-

--- a/doc/tirenvi.txt
+++ b/doc/tirenvi.txt
@@ -25,20 +25,20 @@ Editing remains pure Vim.
 INSTALLATION                                        *tirenvi-install*
 
 Requirements:
-  - Neovim >= 0.9
+  - Neovim >= 0.10
   - External parser command (e.g. tir-csv, tir-gfm-lite)
-  - UTF-8 environment recommended
-
-Install parsers:
-
-    pip install tir-csv
-    pip install tir-gfm-lite
-    pip install tir-pukiwiki
+  - UTF-8 environment
 
 Using lazy.nvim:
 
     {
       "kibi2/tirenvi.nvim",
+      dependencies = {
+        { "kibi2/tir-csv", build = "pip install ." },
+        { "kibi2/tir-gfm-lite", build = "pip install ." },
+        { "kibi2/tir-embedded", build = "pip install ." },
+        { "tpope/vim-repeat" },
+      },
       config = function()
         require("tirenvi").setup()
       end,
@@ -57,6 +57,7 @@ Supported by default:
   - csv
   - tsv
   - markdown
+  - any text file (via Tir-embedded)
   - pukiwiki
 
 Additional formats can be enabled via parser_map.
@@ -64,12 +65,12 @@ Additional formats can be enabled via parser_map.
 Commands:
 
     :Tir redraw
-        Recalculate column widths
+        Synchronize the buffer with the internal table model
 
     :Tir toggle
         Toggle raw ↔ structured view
 
-    :Tir width[=+-][count]
+    :Tir width{=+-}[count]
         Adjust column width
 
         :Tir width=        Auto-fit column width
@@ -77,6 +78,27 @@ Commands:
         :Tir width+        Increase width by 1
         :Tir width+3       Increase width by 3
         :Tir width-        Decrease width by 1
+
+    :Tir fit{=+-}[count]
+        Adjust table width
+
+        :Tir fit=          Auto-fit table width
+        :Tir fit=80        Set table width to 80
+        :Tir fit+          Increase table width by 1
+        :Tir fit+3         Increase table width by 3
+        :Tir fit-          Decrease table width by 1
+
+    :Tir wrap
+        Toggle nowrap ↔ wrap width mode
+
+    :Tir repair enable
+        Enable automatic structural repair.
+
+    :Tir repair disable
+        Disable automatic structural repair.
+
+    :Tir repair toggle
+        Toggle automatic structural repair.
 
 All normal Vim motions and operators work:
   dd, yy, p, cw, visual, :%s, etc.
@@ -123,14 +145,16 @@ To modify a column:
 
 Column width can be adjusted with:
 
-    :Tir width[=+-][count]
+    :Tir width{=+-}[count]
 
-Column width changes are repeatable with `.`.
+Table width can be adjusted with:
+
+    :Tir fit{=+-}[count]
 
 Operations that would break structural alignment
 are automatically corrected.
 
-Column width changes support '.' repeat when vim-repeat is installed.
+Column and table width changes support '.' repeat when vim-repeat is installed.
 
 ============================================================================== 
 MULTILINE CELLS                                     *tirenvi-multiline*
@@ -194,9 +218,26 @@ Default configuration:
                 required_version = "0.1.5",
             },
         },
+        table = {
+          auto_reconcile = true,
+          wrap_mode = "wrap",
+        },
+        ui = {
+          manage_wrap = true,
+        },
     })
 
 parser_map maps filetype → external parser.
+
+auto_reconcile :
+    Enable automatic structural repair.
+    See |:Tir repair|.
+
+wrap_mode:
+    "wrap" or "nowrap".
+    See |:Tir wrap|.
+
+manage_wrap : Automatically enables wrapping for plain text and disables wrapping for grid tables.
 
 ============================================================================== 
 HOW IT WORKS                                        *tirenvi-architecture*
@@ -207,9 +248,9 @@ Core concept:
 
 Workflow:
 
-  flat format (CSV/TSV/Markdown/...) → TIR → tir-vim
-  edit in tir-vim
-  tir-vim → TIR → original flat format
+  flat format (CSV/TSV/Markdown/...) → TIR → tir-buf
+  edit in tir-buf
+  tir-buf → TIR → original flat format
 
 Key properties:
 

--- a/lua/tirenvi/app/filetype.lua
+++ b/lua/tirenvi/app/filetype.lua
@@ -24,7 +24,8 @@ function M.on_filetype(ctx)
 	if old_filetype and old_filetype == new_filetype then
 		return
 	end
-	if old_filetype then
+	local old_parser = buf_state.get(ctx.bufnr, buf_state.IKEY.PARSER)
+	if old_parser then
 		common.to_flat(ctx)
 	end
 	buf_state.set(ctx.bufnr, buf_state.IKEY.FILETYPE, new_filetype)

--- a/lua/tirenvi/parser/parser.lua
+++ b/lua/tirenvi/parser/parser.lua
@@ -93,6 +93,13 @@ local function run_parser(executable, subcmd, options, lines)
 	return result.stdout
 end
 
+---@param version string
+---@return string
+local function normalize_version(version)
+	version = vim.trim(version)
+	return version:match("^%d+%.%d+%.%d+") or version
+end
+
 ---@param self Parser
 ---@return string|nil
 local function get_string_version(self)
@@ -100,11 +107,11 @@ local function get_string_version(self)
 		error({ code = ERR.EXECUTABLE_NOT_FOUND })
 	end
 	self._installed_version =
-		vim.trim(fn.system({ self.executable, "--version" }))
+		normalize_version(fn.system({ self.executable, "--version" }))
 	if vim.v.shell_error ~= 0 then
 		-- TODO
 		self._installed_version =
-			vim.trim(fn.system({ self.executable, "version" }))
+			normalize_version(fn.system({ self.executable, "version" }))
 		if vim.v.shell_error ~= 0 then
 			error({ code = ERR.VERSION_COMMAND_FAILED })
 		end

--- a/lua/tirenvi/version.lua
+++ b/lua/tirenvi/version.lua
@@ -2,6 +2,6 @@
 
 local M = {}
 
-M.VERSION = "0.4.0"
+M.VERSION = "0.5.0"
 
 return M

--- a/tests/cases/check/health/out-expected.txt
+++ b/tests/cases/check/health/out-expected.txt
@@ -1,7 +1,7 @@
 === DISPLAY ===
 ==============================================================================
 tirenvi ~
-- version: 0.4.0
+- version: 0.5.0
 - WARNING vim-repeat not found ('.' repeat disabled)
 - OK tir-csv found
 - OK tir-csv version 0.1.4 OK
@@ -14,7 +14,7 @@ tirenvi ~
 === DISPLAY ===
 ==============================================================================
 tirenvi ~
-- version: 0.4.0
+- version: 0.5.0
 - WARNING vim-repeat not found ('.' repeat disabled)
 - ERROR Could not parse tir-pukiwiki version string: 0.
 - ERROR foo not found.

--- a/tests/cases/check/vim-plug/out-expected.txt
+++ b/tests/cases/check/vim-plug/out-expected.txt
@@ -6,4 +6,4 @@
 - Finishing ... Done!
 - Post-update hook for tir-csv ... OK
 - tir-csv: Already up to date.
-0.0.post1.dev1
+0.1.4

--- a/tests/cases/check/vim-plug/run.sh
+++ b/tests/cases/check/vim-plug/run.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
+
+# test for neovim plugin manager "vim-plug"
+
 set -eu
 
 rm -fr ~/.local/share/vimplug-test

--- a/tests/cases/filetype/out-expected.txt
+++ b/tests/cases/filetype/out-expected.txt
@@ -12,7 +12,10 @@ CASE 10 // cur(1,1) b1:r1:c1+0<│>  g(1,8)n[2*,3,3]
 CASE 18 // cur(1,1) bnil:rnil:cnil+0<1> 
 CASE 18 // cur(1,1) b1:r1:c1+0<│>  g(1,9)n[10*,2]
  
---- CASE 25: filetype markdown -> bar ---
+--- CASE 25: filetype python -> markdown ---
+CASE 25 // cur(1,1) bnil:rnil:cnil+0<#> 
+ 
+--- CASE 30: filetype markdown -> bar ---
 v:true
 markdown
 tir-gfm-lite

--- a/tests/cases/filetype/run.vim
+++ b/tests/cases/filetype/run.vim
@@ -22,6 +22,11 @@ CASE filetype csv -> tsv
         Tir toggle
             sleep 1m | lua print(Debug.layout())
 
+CASE filetype python -> markdown
+    e! $TIRENVI_ROOT/tests/data/sample.py
+        set filetype=markdown
+            sleep 1m | lua print(Debug.layout())
+
 CASE filetype markdown -> bar
     e! $TIRENVI_ROOT/tests/data/simple.md
     call At(2, 3, 1)

--- a/tests/cases/undo/toggle/out-expected.txt
+++ b/tests/cases/undo/toggle/out-expected.txt
@@ -3,9 +3,10 @@
 --- CASE 7: Tir toggle + undo ---
 1 more line; before #2  <time>
 v:false
+1 line less; before #5  <time>
 
 === DISPLAY ===
-1a
+a,2 
 "1
 ",２,"3
 b	"

--- a/tests/cases/undo/toggle/run.vim
+++ b/tests/cases/undo/toggle/run.vim
@@ -9,7 +9,13 @@ CASE Tir toggle + undo
         Tir toggle
         u
             sleep 1m | echomsg b:tirenvi.tirbuf
+        Tir toggle
+        normal! 02x
+            sleep 1m
+        Tir toggle
+        u
     normal! 1G2l
+        Tir toggle
         normal! D
 
 call Snapshot({})


### PR DESCRIPTION
## Summary

Fix flat-mode detection to use parser availability instead of the current filetype.

## Problem

When editing an embedded table in a Python file, changing the buffer filetype to
`markdown` could trigger a stack trace.

The plugin determined whether to switch back to the flat view based only on the
current filetype. After changing the filetype, it incorrectly assumed that a
Markdown parser was available.

## Solution

Determine whether flat mode is available by checking parser availability
instead of relying on the current filetype.

This prevents invalid parser selection and avoids the stack trace when the
buffer filetype is changed.