### PR TITLE
Prepare release v0.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,12 +106,13 @@ Edit tables directly in Vim while preserving a structured internal model.
 
 * Render CSV/TSV/GFM into an aligned structured view
 * Edit tables embedded in any text file (Tir-embedded)
+* Multiline cell support with preserved line breaks
+* Column width control with wrapping support
+* Three width modes: nowrap, wrap, and auto
 * Preserve original file format on save
 * Toggle raw ↔ structured view
 * Immediate or deferred structural repair
 * Dirty line tracking and highlighting
-* Multiline cell support with preserved line breaks
-* Column width control with wrapping support
 * Automatic wrap management for plain and grid views
 * Grid-aware join that preserves column structure
 * Column text objects for structural editing
@@ -221,6 +222,7 @@ require("tirenvi").setup({
 | Command                  | Description                                                         |
 | ------------------------ | ------------------------------------------------------------------- |
 | `:Tir width{=+-}[count]` | Adjust column width by count (`=`: set, `+/-`: increment/decrement) |
+| `:Tir width?`            | Show the current table width settings.                              |
 | `:Tir fit{=+-}[count]`   | Adjust table span by count (`=`: set, `+/-`: increment/decrement)   |
 | `:Tir wrap`              | Toggle nowrap ↔ wrap width mode                                     |
 | `:Tir redraw`            | Redraw and reformat dirty tables                                    |
@@ -238,11 +240,36 @@ All native Vim editing works.
 
 No special editing mode.
 
+### Inspecting the current width settings
+
+Use:
+
+```vim
+:Tir width?
+```
+
+Example output:
+
+```text
+mode=nowrap span=23 col=1/3 header="Name" widths=[5*,3,11]
+```
+
+This displays the current width mode, table span, selected column,
+column widths, and other table information.
+
+### Width modes
+
+Tirenvi supports three width modes:
+
+* **nowrap** – Prevents wrapping inside cells. Best for editing cell contents.
+* **wrap** – Keeps the table within a fixed width by wrapping cell contents.
+* **auto** – Automatically switches between readable wide tables and compact wrapped tables depending on the available window width.
+
 ## Editing Tips
 
 * Inserting a line above the first row of a table creates a normal text line.
 * Inserting a line below the last row appends a new table row.
-* Press `D` (or `S`) at the beginning of a table row to split the table.
+* Press `D` at the beginning of a table row to split the table.
 * Press `D` at the beginning of the second column to clear the cell contents.
 
 ## Column Editing

--- a/doc/tags
+++ b/doc/tags
@@ -1,6 +1,13 @@
+!_TAG_FILE_ENCODING	utf-8	//
 tirenvi	tirenvi.txt	/*tirenvi*
+tirenvi-architecture	tirenvi.txt	/*tirenvi-architecture*
+tirenvi-column	tirenvi.txt	/*tirenvi-column*
 tirenvi-config	tirenvi.txt	/*tirenvi-config*
 tirenvi-health	tirenvi.txt	/*tirenvi-health*
 tirenvi-install	tirenvi.txt	/*tirenvi-install*
+tirenvi-motion	tirenvi.txt	/*tirenvi-motion*
+tirenvi-multiline	tirenvi.txt	/*tirenvi-multiline*
+tirenvi-structure	tirenvi.txt	/*tirenvi-structure*
 tirenvi-usage	tirenvi.txt	/*tirenvi-usage*
+tirenvi-width-mode	tirenvi.txt	/*tirenvi-width-mode*
 tirenvi.txt	tirenvi.txt	/*tirenvi.txt*

--- a/doc/tirenvi.txt
+++ b/doc/tirenvi.txt
@@ -79,6 +79,29 @@ Commands:
         :Tir width+3       Increase width by 3
         :Tir width-        Decrease width by 1
 
+    :Tir width?
+        Show the current width settings.
+
+        Example output:
+
+        mode=nowrap span=23 col=1/3 header="Name" widths=[5*,3,11]
+        
+        mode
+            Current width mode. nowrap|wrap|auto
+
+        span
+            Target table width.
+
+        col
+            Current column index.
+
+        header
+            Current column title.
+
+        widths
+            Column widths.
+            '*' indicates the current column.
+
     :Tir fit{=+-}[count]
         Adjust table width
 
@@ -104,6 +127,33 @@ All normal Vim motions and operators work:
   dd, yy, p, cw, visual, :%s, etc.
 
 No special editing mode is required.
+
+============================================================================== 
+WIDTH MODES                                    *tirenvi-width-mode*
+
+nowrap
+    Cells are never wrapped.
+
+wrap
+    The table width is fixed.
+    Cell contents wrap as needed.
+
+auto
+    Uses nowrap when the table fits in the window.
+    Switches to wrap when necessary.
+
+Changing width mode
+
+:Tir fit=
+        Select auto mode.
+
+:Tir width...
+:Tir fit...
+        Select wrap mode.
+
+:Tir wrap
+        Toggle between nowrap and the previous
+        automatic mode (auto or wrap).
 
 ============================================================================== 
 STRUCTURAL MODEL                                    *tirenvi-structure*
@@ -220,24 +270,39 @@ Default configuration:
         },
         table = {
           auto_reconcile = true,
-          wrap_mode = "wrap",
+          wrap_mode = "auto",
         },
         ui = {
           manage_wrap = true,
         },
     })
 
-parser_map maps filetype → external parser.
+parser_map:
+    maps filetype → external parser.
 
-auto_reconcile :
+table.auto_reconcile:
     Enable automatic structural repair.
-    See |:Tir repair|.
+    See :Tir repair.
 
-wrap_mode:
-    "wrap" or "nowrap".
-    See |:Tir wrap|.
+table.wrap_mode:
+    Initial width mode.
 
-manage_wrap : Automatically enables wrapping for plain text and disables wrapping for grid tables.
+    "nowrap"
+        Start in nowrap mode.
+
+    "auto"
+        Start in auto mode.
+
+    Any other value
+        Defaults to auto mode.
+
+    See :Tir wrap.
+
+manage_wrap:
+    Automatically controls the window's 'wrap' option.
+
+    Wrapping is enabled for plain text and disabled
+    for grid tables.
 
 ============================================================================== 
 HOW IT WORKS                                        *tirenvi-architecture*
@@ -248,9 +313,15 @@ Core concept:
 
 Workflow:
 
-  flat format (CSV/TSV/Markdown/...) → TIR → tir-buf
-  edit in tir-buf
-  tir-buf → TIR → original flat format
+  flat format (CSV/TSV/Markdown/...)
+      ↓
+  TIR
+      ↓
+  tir-buf (editing)
+      ↓
+  TIR
+      ↓
+  original flat format
 
 Key properties:
 

--- a/lua/tirenvi/config.lua
+++ b/lua/tirenvi/config.lua
@@ -48,7 +48,7 @@ local defaults = {
 	},
 	table = {
 		auto_reconcile = true,
-		wrap_mode = "wrap",
+		wrap_mode = "auto",
 	},
 	ui = {
 		manage_wrap = true,


### PR DESCRIPTION
## Summary

Prepare the v0.5.0 release.

## Highlights

- Introduce Tir-embedded support for editing tables embedded in arbitrary text files.
- Add three width modes: `nowrap`, `wrap`, and `auto`.
- Add table width (`fit`) commands and width inspection (`:Tir width?`).
- Add automatic wrap management for plain and grid views.
- Improve cursor restoration after saving.
- Automatically install required parser packages when using lazy.nvim.
- Support opening files saved in tir-buf format.
- Add TIR (ndjson) import/export commands for debugging.

## Improvements

- Reorganize internal modules and layout state handling.
- Improve vertical cursor navigation.
- Update the README and help documentation.
- Expand CI test coverage.
- Fix parser detection when switching filetypes.

## Notes

This release significantly improves the table editing workflow while extending tirenvi beyond Markdown and CSV to support tables embedded in arbitrary text files via Tir-embedded.