### PR TITLE
fix: highlight embedded TIR cell text

### DIFF
--- a/lua/tirenvi/editor/autocmd.lua
+++ b/lua/tirenvi/editor/autocmd.lua
@@ -270,7 +270,7 @@ local function register_buffer_local_autocmds(bufnr)
 				return
 			end
 			local ctx = Context.from_buf(bufnr)
-			ui.special_apply(ctx.winid)
+			ui.special_apply(ctx)
 		end),
 	})
 end

--- a/lua/tirenvi/editor/commands.lua
+++ b/lua/tirenvi/editor/commands.lua
@@ -137,8 +137,8 @@ local function cmd_toggle(ctx)
 	then
 		return
 	end
-	ui.special_apply(ctx.winid)
 	app.toggle(ctx)
+	ui.special_apply(ctx)
 	if buf_state.is_tirbuf(ctx.bufnr) then
 		autocmd.register_buf_autocmd(ctx.bufnr)
 	else

--- a/lua/tirenvi/parser/flat_parser.lua
+++ b/lua/tirenvi/parser/flat_parser.lua
@@ -26,7 +26,7 @@ local M = {}
 ---@return string[] NDJSON lines
 local function flat_to_jslines(parser, fllines, cursor_buf)
 	local options = vim.deepcopy(parser.options) or {}
-	if parser.executable == "tir-embedded" then
+	if Parser.is_embedded(parser) then
 		options[#options + 1] = "--cursor-line=" .. cursor_buf.row_cur
 	end
 	local js_string = Parser.run(parser, "parse", options, fllines)

--- a/lua/tirenvi/parser/parser.lua
+++ b/lua/tirenvi/parser/parser.lua
@@ -189,4 +189,10 @@ function M.is_old(require, target)
 	return require > target
 end
 
+---@param self Parser
+---@return boolean
+function M.is_embedded(self)
+	return self.executable == "tir-embedded"
+end
+
 return M

--- a/lua/tirenvi/ui.lua
+++ b/lua/tirenvi/ui.lua
@@ -3,6 +3,10 @@ local fn = vim.fn
 
 local config = require("tirenvi.config") -- Root
 
+local Parser = require("tirenvi.parser.parser") -- Parser
+
+local buf_state = require("tirenvi.io.buf_state") -- IO
+
 local log = require("tirenvi.util.log") -- Util
 
 -- =============================================================================
@@ -51,11 +55,24 @@ local function special_setup()
 		"Special",
 	})
 	local special = api.nvim_get_hl(ns_id, { name = target })
+	local normal = api.nvim_get_hl(ns_id, { name = "Normal" })
 	api.nvim_set_hl(ns_id, "TirenviPipe", {
 		fg = special.fg,
 		bg = special.bg,
 	})
-	api.nvim_set_hl(ns_id, "TirenviInnerText", {
+	api.nvim_set_hl(ns_id, "TirenviTextNounder", {
+		sp = special.fg,
+	})
+	api.nvim_set_hl(ns_id, "TirenviTextUnder", {
+		underline = true,
+		sp = special.fg,
+	})
+	api.nvim_set_hl(ns_id, "TirenviTextNounderEmbedded", {
+		fg = normal.fg,
+		sp = special.fg,
+	})
+	api.nvim_set_hl(ns_id, "TirenviTextUnderEmbedded", {
+		fg = normal.fg,
 		underline = true,
 		sp = special.fg,
 	})
@@ -111,8 +128,9 @@ function M.special_clear(winid)
 	matches[winid] = nil
 end
 
----@param winid integer
-function M.special_apply(winid)
+---@param ctx Context
+function M.special_apply(ctx)
+	local winid = ctx.winid
 	local pipen = config.marks.pipe
 	local pipec = config.marks.pipec
 	M.special_clear(winid)
@@ -122,7 +140,19 @@ function M.special_apply(winid)
 	add_match(winid, "TirenviPipe", pat_v(pipec), 30)
 	add_match(winid, "TirenviPipe", pat_v(pipen), 30)
 	add_match(winid, "TirenviInnerPipe", pat_inner_pipe(pipen), 40)
-	add_match(winid, "TirenviInnerText", pat_inner_text(pipen), 50)
+	local parser = buf_state.get(ctx.bufnr, buf_state.IKEY.PARSER)
+	if Parser.is_embedded(parser) then
+		add_match(
+			winid,
+			"TirenviTextNounderEmbedded",
+			pat_inner_text(pipec),
+			50
+		)
+		add_match(winid, "TirenviTextUnderEmbedded", pat_inner_text(pipen), 50)
+	else
+		add_match(winid, "TirenviTextNounder", pat_inner_text(pipec), 50)
+		add_match(winid, "TirenviTextUnder", pat_inner_text(pipen), 50)
+	end
 	vim.opt_local.conceallevel = config.ui.conceal.level
 	vim.opt_local.concealcursor = config.ui.conceal.cursor
 	local pattern = fn.escape(pipec, [[/\]])

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -5,6 +5,7 @@
 out-actual.txt
 gen*
 diff-*
+work
 
 # Captured logs
 stdout.txt


### PR DESCRIPTION
### Summary

Improve highlighting of cell text in embedded TIR tables.

* Keep the existing highlighting for regular TIR tables.
* Use a dedicated highlight for cell text in embedded TIR.
* Make embedded TIR cell text use a normal foreground color instead of the host language's comment color.
* Keep the existing underline behavior for `pipen` content.

This makes embedded TIR tables easier to read while leaving CSV and Markdown highlighting unchanged.
