### PR TITLE
feat: add structural motions for cells and blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.5.1] - 2026-08-16
+
+### Added
+
+- Added structural motions for TIR buffers:
+  - `block_top`
+  - `block_bottom`
+  - `cell_next`
+  - `cell_prev`
+- Structural motions support counts and Visual mode.
+- Added default key mappings using `Ctrl-h/j/k/l`:
+  - `Ctrl-h`: previous cell
+  - `Ctrl-l`: next cell
+  - `Ctrl-k`: top of block
+  - `Ctrl-j`: bottom of block
+
 ## [0.5.0] - 2026-07-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Edit tables directly in Vim while preserving a structured internal model.
 * Automatic wrap management for plain and grid views
 * Grid-aware join that preserves column structure
 * Column text objects for structural editing
+* Structural motions for navigating between cells and blocks
 * Works with native Vim motions and operators
 * External parser architecture (extensible)
 * Uses standard Vim editing
@@ -295,9 +296,31 @@ are automatically corrected.
 Column width operations support `.` repeat when
 [`vim-repeat`](https://github.com/tpope/vim-repeat) is installed.
 
-## Pipe Motions
+## Motions
 
-Fast horizontal navigation across cells.
+### Structural Motions
+
+Navigate through the logical structure of a TIR buffer.
+
+```lua
+vim.keymap.set({ 'n', 'o', 'x' }, '<C-h>', require('tirenvi').motion.cell_prev,
+  { expr = true, desc = 'TirEnvi: previous cell' })
+vim.keymap.set({ 'n', 'o', 'x' }, '<C-l>', require('tirenvi').motion.cell_next,
+  { expr = true, desc = 'TirEnvi: next cell' })
+vim.keymap.set({ 'n', 'o', 'x' }, '<C-k>', require('tirenvi').motion.block_top,
+  { expr = true, desc = 'TirEnvi: block top' })
+vim.keymap.set({ 'n', 'o', 'x' }, '<C-j>', require('tirenvi').motion.block_bottom,
+  { expr = true, desc = 'TirEnvi: block bottom' })
+````
+
+* `Ctrl-h` / `Ctrl-l`: previous / next cell
+* `Ctrl-k` / `Ctrl-j`: top / bottom of block
+
+These motions support counts and Visual mode.
+
+### Pipe Motions
+
+Navigate horizontally by table separators.
 
 ```lua
 vim.keymap.set({ 'n', 'o', 'x' }, '<leader>tf', require('tirenvi').motion.f, { expr = true })
@@ -306,7 +329,7 @@ vim.keymap.set({ 'n', 'o', 'x' }, '<leader>tt', require('tirenvi').motion.t, { e
 vim.keymap.set({ 'n', 'o', 'x' }, '<leader>tT', require('tirenvi').motion.T, { expr = true })
 ```
 
-They behave like Vim’s `f/F/t/T`,
+They behave like Vim's `f/F/t/T`,
 but target table separators.
 
 `;` and `,` continue to repeat as usual.

--- a/doc/tirenvi.txt
+++ b/doc/tirenvi.txt
@@ -220,7 +220,35 @@ When column width is smaller than content:
   - Wrapped vs non-wrapped cells are visually distinguishable
     using underline-based row separators
 
-============================================================================== 
+==============================================================================
+STRUCTURAL MOTIONS
+
+tirenvi provides motions for navigating the logical structure of a TIR buffer.
+
+Available Lua functions:
+
+    require("tirenvi").motion.cell_prev
+    require("tirenvi").motion.cell_next
+    require("tirenvi").motion.block_top
+    require("tirenvi").motion.block_bottom
+
+These motions navigate between cells and blocks.
+
+They support counts and Visual mode.
+
+Example mapping:
+
+    vim.keymap.set({ 'n', 'x' }, '<C-h>',
+        require('tirenvi').motion.cell_prev, { expr = true })
+    vim.keymap.set({ 'n', 'x' }, '<C-l>',
+        require('tirenvi').motion.cell_next, { expr = true })
+    vim.keymap.set({ 'n', 'x' }, '<C-k>',
+        require('tirenvi').motion.block_top, { expr = true })
+    vim.keymap.set({ 'n', 'x' }, '<C-j>',
+        require('tirenvi').motion.block_bottom, { expr = true })
+
+
+==============================================================================
 PIPE MOTIONS                                        *tirenvi-motion*
 
 tirenvi provides pipe-aware motions for fast horizontal navigation.


### PR DESCRIPTION
## Summary

Add structural motions for navigating TIR buffers by cell and block.

### Changes

- Add `cell_prev` / `cell_next` motions
- Add `block_top` / `block_bottom` motions
- Support counts and Visual mode
- Add structural motion key mappings using `Ctrl-h/j/k/l`
- Keep existing pipe motions (`f/F/t/T`) unchanged

These motions navigate the logical structure of a TIR buffer rather than relying only on physical cursor movement.