### PR TITLE
fix: update version.lua to v0.5.1

### DIFF
--- a/lua/tirenvi/version.lua
+++ b/lua/tirenvi/version.lua
@@ -2,6 +2,6 @@
 
 local M = {}
 
-M.VERSION = "0.5.0"
+M.VERSION = "0.5.1"
 
 return M

--- a/tests/cases/check/health/out-expected.txt
+++ b/tests/cases/check/health/out-expected.txt
@@ -1,7 +1,7 @@
 === DISPLAY ===
 ==============================================================================
 tirenvi ~
-- version: 0.5.0
+- version: 0.5.1
 - WARNING vim-repeat not found ('.' repeat disabled)
 - OK tir-csv found
 - OK tir-csv version 0.1.4 OK
@@ -14,7 +14,7 @@ tirenvi ~
 === DISPLAY ===
 ==============================================================================
 tirenvi ~
-- version: 0.5.0
+- version: 0.5.1
 - WARNING vim-repeat not found ('.' repeat disabled)
 - ERROR Could not parse tir-pukiwiki version string: 0.
 - ERROR foo not found.


### PR DESCRIPTION
Fixed the missing update in version.lua.

In line with the release of tirenvi v0.5.1, the version in version.lua has been updated to v0.5.1.