### PR TITLE
chore: prepare release v0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.5.2] - 2026-08-17
+
+### Fixed
+
+- Fix compatibility with the updated `vim.str_byteindex` and `vim.str_utfindex` API in Neovim 0.11+ while retaining support for Neovim 0.10.
+- Remove the deprecation warning reported by `:checkhealth` on newer Neovim versions.
+
 ## [0.5.1] - 2026-08-16
 
 ### Added

--- a/lua/tirenvi/version.lua
+++ b/lua/tirenvi/version.lua
@@ -2,6 +2,6 @@
 
 local M = {}
 
-M.VERSION = "0.5.1"
+M.VERSION = "0.5.2"
 
 return M

--- a/tests/cases/check/health/out-expected.txt
+++ b/tests/cases/check/health/out-expected.txt
@@ -1,7 +1,7 @@
 === DISPLAY ===
 ==============================================================================
 tirenvi ~
-- version: 0.5.1
+- version: 0.5.2
 - WARNING vim-repeat not found ('.' repeat disabled)
 - OK tir-csv found
 - OK tir-csv version 0.1.4 OK
@@ -14,7 +14,7 @@ tirenvi ~
 === DISPLAY ===
 ==============================================================================
 tirenvi ~
-- version: 0.5.1
+- version: 0.5.2
 - WARNING vim-repeat not found ('.' repeat disabled)
 - ERROR Could not parse tir-pukiwiki version string: 0.
 - ERROR foo not found.


### PR DESCRIPTION
## Summary

Prepare the v0.5.2 release.

### Changes

- Update `vim.str_byteindex` handling for compatibility with Neovim 0.11+
- Retain compatibility with Neovim 0.10
- Remove the deprecation warning reported by `:checkhealth`
- Update `version.lua` to v0.5.2
- Update `CHANGELOG.md`