### PR TITLE
Feat/textobj cell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.5.3] - 2026-08-18
+
+### Added
+
+- Add cell text objects `vic` and `vac` for selecting cell content or cells including the left border.
+- Support multi-line selection for wrapped cells.
+
 ## [0.5.2] - 2026-08-17
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -233,7 +233,13 @@ require("tirenvi").setup({
 | `:Tir repair toggle`     | Toggle automatic structural repair                                  |
 | `:Tir repair`            | Deprecated. Will be removed in v0.6.<br>Use `:Tir redraw` instead   |
 
-All native Vim editing works.
+Operations that would break structure
+are automatically corrected.
+
+Column width operations support `.` repeat when
+[`vim-repeat`](https://github.com/tpope/vim-repeat) is installed.
+
+Native Vim editing commands work as usual.
 
 * `dd`, `yy`, `p`, `D`, `o`, `R`, `J`, and more
 * Command-line command
@@ -286,15 +292,24 @@ To modify a column:
 require("tirenvi").setup({
   textobj = {
     column = "l",
+    cell = "c",
   },
 })
 ```
 
-Operations that would break structure
-are automatically corrected.
+## Cell Editing
 
-Column width operations support `.` repeat when
-[`vim-repeat`](https://github.com/tpope/vim-repeat) is installed.
+Cells are structural units within a table.
+
+To modify a cell:
+
+1. Select a cell using text objects (`vic`, `vac`, `v3ac`)
+2. Apply standard operators (`d`, `y`, `p`, etc.)
+
+`vic` selects the cell content without the left border, while
+`vac` also includes the left border.
+
+Wrapped cells are selected across multiple lines.
 
 ## Motions
 
@@ -348,12 +363,13 @@ It is a structured text editor layer.
 
 ## Roadmap
 
-### In Progress
+### Ideas
 
-* Text objects (table, row, cell)
-
-### Planned
-
+* VS Code support
+* Copy and paste data with spreadsheets
+* Simple calculations (`sum`, `count`, `ave`, `max`, `min`, sequence numbers)
+* Sort rows and columns
+* Integration with `hydra.nvim`
 * Outline mode
 
 ## Comparison

--- a/doc/tags
+++ b/doc/tags
@@ -1,6 +1,7 @@
 !_TAG_FILE_ENCODING	utf-8	//
 tirenvi	tirenvi.txt	/*tirenvi*
 tirenvi-architecture	tirenvi.txt	/*tirenvi-architecture*
+tirenvi-cell	tirenvi.txt	/*tirenvi-cell*
 tirenvi-column	tirenvi.txt	/*tirenvi-column*
 tirenvi-config	tirenvi.txt	/*tirenvi-config*
 tirenvi-health	tirenvi.txt	/*tirenvi-health*

--- a/doc/tirenvi.txt
+++ b/doc/tirenvi.txt
@@ -206,6 +206,29 @@ are automatically corrected.
 
 Column and table width changes support '.' repeat when vim-repeat is installed.
 
+==============================================================================
+CELL EDITING                                        *tirenvi-cell*
+
+Cells are structural units within a table.
+
+To modify a cell:
+
+  1. Select a cell using text objects:
+       vic   inner cell
+       vac   around cell
+       v3ac  select 3 cells
+
+  2. Apply normal operators (d, c, y, p, etc.)
+
+  `vic` selects the cell content without the left border.
+  `vac` also includes the left border.
+
+When a cell is wrapped across multiple lines,
+the entire cell is selected.
+
+Operations that would break structural alignment
+are automatically corrected.
+
 ============================================================================== 
 MULTILINE CELLS                                     *tirenvi-multiline*
 

--- a/lua/tirenvi/config.lua
+++ b/lua/tirenvi/config.lua
@@ -45,6 +45,7 @@ local defaults = {
 	},
 	textobj = {
 		column = "l",
+		cell = "c",
 	},
 	table = {
 		auto_reconcile = true,

--- a/lua/tirenvi/editor/textobj.lua
+++ b/lua/tirenvi/editor/textobj.lua
@@ -24,20 +24,23 @@ local M = {}
 -- =============================================================================
 --#region Private
 
+---@param ctx Context
 ---@param lines string[]
----@param attr Attr
----@param count integer
----@param row_cur integer
----@param col_byte integer
 ---@param is_around boolean
 ---@return Rect|nil
-local function get_block_rect(lines, attr, count, row_cur, col_byte, is_around)
-	local cline = lines[row_cur - attr.range.first + 1]
+local function get_block_rect(ctx, lines, is_around)
+	local count = vim.v.count1
+	local cursor_buf = CursorNvim.capture(ctx)
+	local attrs = buf_state.get(ctx.bufnr, buf_state.IKEY.ATTRS)
+	local attr = Attrs.get(attrs, cursor_buf.row_cur)
+	assert(attr ~= nil)
+	local cline = lines[cursor_buf.row_cur - attr.range.first + 1]
 	local cbyte_pos = tir_buf.get_pipe_byte_positions(cline)
 	if #cbyte_pos == 0 then
 		return nil
 	end
-	local icol_start = tir_buf.get_current_col_index(cbyte_pos, col_byte)
+	local icol_start =
+		tir_buf.get_current_col_index(cbyte_pos, cursor_buf.col_byte)
 	if not icol_start or icol_start == 0 then
 		return nil
 	end
@@ -62,28 +65,10 @@ end
 ---@param is_around boolean
 local function setup_vl(lines, is_around)
 	local ctx = Context.from_buf()
-	local count = vim.v.count1
-	local cursor_buf = CursorNvim.capture(ctx)
-	local attrs = buf_state.get(ctx.bufnr, buf_state.IKEY.ATTRS)
-	if not attrs then
-		return
-	end
-	local attr = Attrs.get(attrs, cursor_buf.row_cur)
-	if not attr then
-		return nil
-	end
-	local rect = get_block_rect(
-		lines,
-		attr,
-		count,
-		cursor_buf.row_cur,
-		cursor_buf.col_byte,
-		is_around
-	)
+	local rect = get_block_rect(ctx, lines, is_around)
 	if not rect then
 		return
 	end
-	local lines = buf_lines.get_lines(ctx.bufnr, rect.row.first, rect.row.last)
 	if not buf_parser.table_is_aligned(lines) then
 		notify.error(errors.ERR.TABLE_IS_NOT_ALIGNED)
 		return
@@ -95,15 +80,14 @@ local function setup_vl(lines, is_around)
 end
 
 ---@return string[]|nil
-local function get_lines()
+local function get_block_lines()
 	local ctx = Context.from_buf()
-	local cursor_buf = CursorNvim.capture(ctx)
-	local row_cur = cursor_buf.row_cur
 	local attrs = buf_state.get(ctx.bufnr, buf_state.IKEY.ATTRS)
 	if not attrs then
 		return
 	end
-	local attr = Attrs.get(attrs, row_cur)
+	local cursor_buf = CursorNvim.capture(ctx)
+	local attr = Attrs.get(attrs, cursor_buf.row_cur)
 	if not attr then
 		return nil
 	end
@@ -111,14 +95,14 @@ local function get_lines()
 end
 
 local function setup_vil()
-	local lines = get_lines()
+	local lines = get_block_lines()
 	if lines then
 		setup_vl(lines, false)
 	end
 end
 
 local function setup_val()
-	local lines = get_lines()
+	local lines = get_block_lines()
 	if lines then
 		setup_vl(lines, true)
 	end

--- a/lua/tirenvi/editor/textobj.lua
+++ b/lua/tirenvi/editor/textobj.lua
@@ -24,19 +24,15 @@ local M = {}
 -- =============================================================================
 --#region Private
 
----@param ctx Context
----@param attrs Attr[]
+---@param lines string[]
+---@param attr Attr
 ---@param count integer
 ---@param row_cur integer
 ---@param col_byte integer
 ---@param is_around boolean
 ---@return Rect|nil
-local function get_block_rect(ctx, attrs, count, row_cur, col_byte, is_around)
-	local attr = Attrs.get(attrs, row_cur)
-	if not attr then
-		return nil
-	end
-	local cline = ctx.line_provider.get_line(row_cur) or ""
+local function get_block_rect(lines, attr, count, row_cur, col_byte, is_around)
+	local cline = lines[row_cur - attr.range.first + 1]
 	local cbyte_pos = tir_buf.get_pipe_byte_positions(cline)
 	if #cbyte_pos == 0 then
 		return nil
@@ -46,8 +42,8 @@ local function get_block_rect(ctx, attrs, count, row_cur, col_byte, is_around)
 		return nil
 	end
 	icol_start = math.min(icol_start, #cbyte_pos - 1)
-	local tline = ctx.line_provider.get_line(attr.range.first) or ""
-	local bline = ctx.line_provider.get_line(attr.range.last) or ""
+	local tline = lines[1]
+	local bline = lines[#lines]
 	local tbyte_pos = tir_buf.get_pipe_byte_positions(tline)
 	local bbyte_pos = tir_buf.get_pipe_byte_positions(bline)
 	local icol_end = icol_start + count
@@ -64,7 +60,7 @@ local function get_block_rect(ctx, attrs, count, row_cur, col_byte, is_around)
 end
 
 ---@param is_around boolean
-local function setup_vl(is_around)
+local function setup_vl(lines, is_around)
 	local ctx = Context.from_buf()
 	local count = vim.v.count1
 	local cursor_buf = CursorNvim.capture(ctx)
@@ -72,9 +68,13 @@ local function setup_vl(is_around)
 	if not attrs then
 		return
 	end
+	local attr = Attrs.get(attrs, cursor_buf.row_cur)
+	if not attr then
+		return nil
+	end
 	local rect = get_block_rect(
-		ctx,
-		attrs,
+		lines,
+		attr,
 		count,
 		cursor_buf.row_cur,
 		cursor_buf.col_byte,
@@ -94,12 +94,42 @@ local function setup_vl(is_around)
 	CursorNvim.move_byte(ctx, rect.row.last, rect.col.last)
 end
 
+---@return string[]|nil
+local function get_lines()
+	local ctx = Context.from_buf()
+	local cursor_buf = CursorNvim.capture(ctx)
+	local row_cur = cursor_buf.row_cur
+	local attrs = buf_state.get(ctx.bufnr, buf_state.IKEY.ATTRS)
+	if not attrs then
+		return
+	end
+	local attr = Attrs.get(attrs, row_cur)
+	if not attr then
+		return nil
+	end
+	return buf_lines.get_lines(ctx.bufnr, attr.range.first, attr.range.last)
+end
+
 local function setup_vil()
-	setup_vl(false)
+	local lines = get_lines()
+	if lines then
+		setup_vl(lines, false)
+	end
 end
 
 local function setup_val()
-	setup_vl(true)
+	local lines = get_lines()
+	if lines then
+		setup_vl(lines, true)
+	end
+end
+
+local function setup_vic()
+	-- setup_vc(false)
+end
+
+local function setup_vac()
+	-- setup_vc(true)
 end
 
 --#endregion
@@ -112,6 +142,12 @@ function M.setup()
 	})
 	vim.keymap.set({ "x" }, "a" .. config.textobj.column, setup_val, {
 		desc = "Around column",
+	})
+	vim.keymap.set({ "x" }, "i" .. config.textobj.cell, setup_vic, {
+		desc = "Inner cell",
+	})
+	vim.keymap.set({ "x" }, "a" .. config.textobj.cell, setup_vac, {
+		desc = "Around cell",
 	})
 end
 

--- a/lua/tirenvi/editor/textobj.lua
+++ b/lua/tirenvi/editor/textobj.lua
@@ -27,14 +27,14 @@ local M = {}
 ---@param ctx Context
 ---@param lines string[]
 ---@param is_around boolean
----@return Rect|nil
+---@return Range|nil
 local function get_block_rect(ctx, lines, is_around)
 	local count = vim.v.count1
 	local cursor_buf = CursorNvim.capture(ctx)
 	local attrs = buf_state.get(ctx.bufnr, buf_state.IKEY.ATTRS)
 	local attr = Attrs.get(attrs, cursor_buf.row_cur)
 	assert(attr ~= nil)
-	local cline = lines[cursor_buf.row_cur - attr.range.first + 1]
+	local cline = buf_lines.get_line(ctx.bufnr, cursor_buf.row_cur) or ""
 	local cbyte_pos = tir_buf.get_pipe_byte_positions(cline)
 	if #cbyte_pos == 0 then
 		return nil
@@ -52,35 +52,33 @@ local function get_block_rect(ctx, lines, is_around)
 	local icol_end = icol_start + count
 	icol_end = math.min(icol_end, #bbyte_pos)
 	local pipe = tir_buf.get_pipe_char(tline)
-	local rect = {
-		row = Range.copy(attr.range),
-		col = Range.from_lua(
-			tbyte_pos[icol_start] + (is_around and 0 or #pipe),
-			bbyte_pos[icol_end] - 1
-		),
-	}
-	return rect
+	return Range.from_lua(
+		tbyte_pos[icol_start] + (is_around and 0 or #pipe),
+		bbyte_pos[icol_end] - 1
+	)
 end
 
 ---@param is_around boolean
-local function setup_vl(lines, is_around)
+local function setup_vl(row_range, is_around)
 	local ctx = Context.from_buf()
-	local rect = get_block_rect(ctx, lines, is_around)
-	if not rect then
+	local lines =
+		buf_lines.get_lines(ctx.bufnr, row_range.first, row_range.last)
+	local col_range = get_block_rect(ctx, lines, is_around)
+	if not col_range then
 		return
 	end
 	if not buf_parser.table_is_aligned(lines) then
 		notify.error(errors.ERR.TABLE_IS_NOT_ALIGNED)
 		return
 	end
-	CursorNvim.move_byte(ctx, rect.row.first, rect.col.first)
+	CursorNvim.move_byte(ctx, row_range.first, col_range.first)
 	api.nvim_feedkeys(vim.keycode("<C-v>"), "n", false)
 	vim.cmd("normal! o")
-	CursorNvim.move_byte(ctx, rect.row.last, rect.col.last)
+	CursorNvim.move_byte(ctx, row_range.last, col_range.last)
 end
 
 ---@return string[]|nil
-local function get_block_lines()
+local function get_block_rows()
 	local ctx = Context.from_buf()
 	local attrs = buf_state.get(ctx.bufnr, buf_state.IKEY.ATTRS)
 	if not attrs then
@@ -91,20 +89,20 @@ local function get_block_lines()
 	if not attr then
 		return nil
 	end
-	return buf_lines.get_lines(ctx.bufnr, attr.range.first, attr.range.last)
+	return attr.range
 end
 
 local function setup_vil()
-	local lines = get_block_lines()
-	if lines then
-		setup_vl(lines, false)
+	local row_range = get_block_rows()
+	if row_range then
+		setup_vl(row_range, false)
 	end
 end
 
 local function setup_val()
-	local lines = get_block_lines()
-	if lines then
-		setup_vl(lines, true)
+	local row_range = get_block_rows()
+	if row_range then
+		setup_vl(row_range, true)
 	end
 end
 

--- a/lua/tirenvi/editor/textobj.lua
+++ b/lua/tirenvi/editor/textobj.lua
@@ -28,23 +28,23 @@ local M = {}
 ---@param lines string[]
 ---@param is_around boolean
 ---@return Range|nil
-local function get_block_rect(ctx, lines, is_around)
+local function get_col_range(ctx, lines, is_around)
 	local count = vim.v.count1
 	local cursor_buf = CursorNvim.capture(ctx)
 	local attrs = buf_state.get(ctx.bufnr, buf_state.IKEY.ATTRS)
 	local attr = Attrs.get(attrs, cursor_buf.row_cur)
 	assert(attr ~= nil)
 	local cline = buf_lines.get_line(ctx.bufnr, cursor_buf.row_cur) or ""
-	local cbyte_pos = tir_buf.get_pipe_byte_positions(cline)
-	if #cbyte_pos == 0 then
+	local byte_pos = tir_buf.get_pipe_byte_positions(cline)
+	if #byte_pos == 0 then
 		return nil
 	end
 	local icol_start =
-		tir_buf.get_current_col_index(cbyte_pos, cursor_buf.col_byte)
+		tir_buf.get_current_col_index(byte_pos, cursor_buf.col_byte)
 	if not icol_start or icol_start == 0 then
 		return nil
 	end
-	icol_start = math.min(icol_start, #cbyte_pos - 1)
+	icol_start = math.min(icol_start, #byte_pos - 1)
 	local tline = lines[1]
 	local bline = lines[#lines]
 	local tbyte_pos = tir_buf.get_pipe_byte_positions(tline)
@@ -59,11 +59,11 @@ local function get_block_rect(ctx, lines, is_around)
 end
 
 ---@param is_around boolean
-local function setup_vl(row_range, is_around)
+local function setup_visual_block(row_range, is_around)
 	local ctx = Context.from_buf()
 	local lines =
 		buf_lines.get_lines(ctx.bufnr, row_range.first, row_range.last)
-	local col_range = get_block_rect(ctx, lines, is_around)
+	local col_range = get_col_range(ctx, lines, is_around)
 	if not col_range then
 		return
 	end
@@ -77,7 +77,7 @@ local function setup_vl(row_range, is_around)
 	CursorNvim.move_byte(ctx, row_range.last, col_range.last)
 end
 
----@return string[]|nil
+---@return Range|nil
 local function get_block_rows()
 	local ctx = Context.from_buf()
 	local attrs = buf_state.get(ctx.bufnr, buf_state.IKEY.ATTRS)
@@ -92,26 +92,44 @@ local function get_block_rows()
 	return attr.range
 end
 
-local function setup_vil()
+---@return Range|nil
+local function get_cell_rows()
+	local ctx = Context.from_buf()
+	local cursor_buf = CursorNvim.capture(ctx)
+	return tir_buf.get_continue_range(
+		ctx.line_provider,
+		Range.from_lua(cursor_buf.row_cur, cursor_buf.row_cur)
+	)
+end
+
+local function setup_vl(is_around)
 	local row_range = get_block_rows()
 	if row_range then
-		setup_vl(row_range, false)
+		setup_visual_block(row_range, is_around)
 	end
 end
 
+local function setup_vil()
+	setup_vl(false)
+end
+
 local function setup_val()
-	local row_range = get_block_rows()
+	setup_vl(true)
+end
+
+local function setup_vc(is_around)
+	local row_range = get_cell_rows()
 	if row_range then
-		setup_vl(row_range, true)
+		setup_visual_block(row_range, is_around)
 	end
 end
 
 local function setup_vic()
-	-- setup_vc(false)
+	setup_vc(false)
 end
 
 local function setup_vac()
-	-- setup_vc(true)
+	setup_vc(true)
 end
 
 --#endregion

--- a/lua/tirenvi/parser/dirty_range.lua
+++ b/lua/tirenvi/parser/dirty_range.lua
@@ -16,37 +16,11 @@ local M = {}
 --#region Private
 
 ---@param line_provider LineProvider
----@param range Range
-local function expand_continue_lines(line_provider, range)
-	if Range.is_empty(range) then
-		return
-	end
-	local first, last = Range.to_lua(range)
-	local lines = line_provider.get_lines(first, last)
-	local prev = range.first - 1
-	local prev_line = line_provider.get_line(prev)
-	while tir_buf.is_continue_line(prev_line) do
-		prev = prev - 1
-		prev_line = line_provider.get_line(prev)
-	end
-	range.first = prev + 1
-	---@type string|nil
-	local last_line = lines[#lines]
-	local last = range.last
-	while tir_buf.is_continue_line(last_line) do
-		last = last + 1
-		last_line = line_provider.get_line(last)
-	end
-	range.last = last
-end
-
----@param line_provider LineProvider
 ---@param range3 Range3
 ---@return Range
 local function get_new_range(line_provider, range3)
-	local new_range = Range3.get_new_range(range3)
-	expand_continue_lines(line_provider, new_range)
-	return new_range
+	local range = Range3.get_new_range(range3)
+	return tir_buf.get_continue_range(line_provider, range)
 end
 
 ---@param line_provider LineProvider

--- a/lua/tirenvi/parser/tir_buf.lua
+++ b/lua/tirenvi/parser/tir_buf.lua
@@ -3,6 +3,7 @@ local config = require("tirenvi.config") -- Root
 local Cell = require("tirenvi.core.cell") -- Core
 
 local util = require("tirenvi.util.util") -- Util
+local Range = require("tirenvi.util.range")
 local log = require("tirenvi.util.log")
 
 -- =============================================================================
@@ -36,6 +37,16 @@ local function remove_end_pipe(line)
 		line = line:sub(1, -#pipec - 1)
 	end
 	return line
+end
+
+---@param line string|nil
+---@return boolean
+local function is_continue_line(line)
+	local pipec = config.marks.pipec
+	if not line then
+		return false
+	end
+	return M.get_pipe_char(line) == pipec
 end
 
 --#endregion
@@ -141,16 +152,6 @@ function M.has_pipe(lines)
 	return false
 end
 
----@param line string|nil
----@return boolean
-function M.is_continue_line(line)
-	local pipec = config.marks.pipec
-	if not line then
-		return false
-	end
-	return M.get_pipe_char(line) == pipec
-end
-
 ---@param line string
 ---@param embedded_key string|nil
 ---@return string
@@ -168,6 +169,29 @@ function M.split_prefix(line, embedded_key)
 		return "", line
 	end
 	return prefix, string.sub(line, byte_pos[1])
+end
+
+---@param line_provider LineProvider
+---@param range Range
+function M.get_continue_range(line_provider, range)
+	if Range.is_empty(range) then
+		return range
+	end
+	local first, last = Range.to_lua(range)
+	local prev = first - 1
+	local prev_line = line_provider.get_line(prev)
+	while is_continue_line(prev_line) do
+		prev = prev - 1
+		prev_line = line_provider.get_line(prev)
+	end
+	local next = last
+	---@type string|nil
+	local next_line = line_provider.get_line(next)
+	while is_continue_line(next_line) do
+		next = next + 1
+		next_line = line_provider.get_line(next)
+	end
+	return Range.from_lua(prev + 1, next)
 end
 
 return M

--- a/lua/tirenvi/version.lua
+++ b/lua/tirenvi/version.lua
@@ -2,6 +2,6 @@
 
 local M = {}
 
-M.VERSION = "0.5.2"
+M.VERSION = "0.5.3"
 
 return M

--- a/tests/cases/check/health/out-expected.txt
+++ b/tests/cases/check/health/out-expected.txt
@@ -1,7 +1,7 @@
 === DISPLAY ===
 ==============================================================================
 tirenvi ~
-- version: 0.5.2
+- version: 0.5.3
 - WARNING vim-repeat not found ('.' repeat disabled)
 - OK tir-csv found
 - OK tir-csv version 0.1.4 OK
@@ -14,7 +14,7 @@ tirenvi ~
 === DISPLAY ===
 ==============================================================================
 tirenvi ~
-- version: 0.5.2
+- version: 0.5.3
 - WARNING vim-repeat not found ('.' repeat disabled)
 - ERROR Could not parse tir-pukiwiki version string: 0.
 - ERROR foo not found.

--- a/tests/cases/textobj/vaic/out-expected.txt
+++ b/tests/cases/textobj/vaic/out-expected.txt
@@ -1,66 +1,42 @@
---- CSV ---
 === MESSAGE ===
  
 --- CASE 8: initial cached attrs ---
 CASE 8 // cur(1,5) b1:r1:c2+1<2>  g(1,7)n[2,3*,3]
  
---- CASE 12: yank column and put ---
-block of 7 lines yanked
-CASE 12 // cur(1,12) b1:r1:c4+0<│>  g(1,7)n[2,3,3,3*]
- 
---- CASE 19: yank 2column and put ---
-CASE 19 // cur(7,3) b1:r7:c1+2<⠀>  g(1,7)n[2*,3,3,3]
-block of 7 lines yanked
-CASE 19 // cur(1,1) b1:r1:c1+0<│>  g(1,7)n[2*,3,2,3,3,3]
- 
---- CASE 28: repair disable ---
-[Tirenvi] repair:disable 
-tirenvi: Cannot select column: table is not aligned.
+--- CASE 12: dlete column and put ---
+CASE 12 // cur(1,11) b1:r1:c3+2<│>  g(1,7)n[2,3,2*]
 
 === DISPLAY ===
-│1a│2 a│1a│2 a│３a│2 a│
-┊1↲┊２⠀┊1↲┊２⠀┊3↲⠀┊２⠀┊
-│⠀⠀│⠀⠀⠀│⠀⠀│⠀⠀⠀│b⇥⠀│⠀⠀⠀│
-┊↲⠀┊⠀⠀⠀┊↲⠀┊⠀⠀⠀┊⇥c⠀┊⠀⠀⠀┊
-┊insert↲⠀┊⠀⠀⠀┊↲⠀┊⠀⠀⠀┊⠀⠀⠀┊⠀⠀⠀┊
-┊↲⠀┊⠀⠀⠀┊↲⠀┊⠀⠀⠀┊⠀⠀⠀┊⠀⠀⠀┊
-│⠀⠀│⠀⠀⠀│⠀⠀│⠀⠀⠀│⠀⠀⠀│⠀⠀⠀│
---- GFM ---
+│1a│３a│ 2 a│
+┊1↲┊２⠀┊3↲⠀⠀┊
+│⠀⠀│⠀⠀⠀│b⇥⠀⠀│
+┊↲⠀┊⠀⠀⠀┊⇥c⠀⠀┊
+┊↲⠀┊⠀⠀⠀┊⠀⠀⠀⠀┊
+┊↲⠀┊⠀⠀⠀┊⠀⠀⠀⠀┊
+│⠀⠀│⠀⠀⠀│⠀⠀⠀⠀│
 === MESSAGE ===
  
---- CASE 39: initial cached attrs ---
-CASE 39 // cur(1,1) b1:r1:c0+0<g>  p(1,2)* g(3,8)n[5,3,11] p(9,11)
- 
---- CASE 43: yank plain ---
-CASE 43 // cur(1,3) b1:r1:c0+0<g>  p(1,2)* g(3,8)n[5,3,11] p(9,11)
- 
---- CASE 50: yank 2column and put ---
-block of 6 lines yanked
-CASE 50 // cur(3,8) b2:r1:c2+1<│>  p(1,2) g(3,8)n[5,2*,3,11,3,11] p(9,11)
+--- CASE 21: yank cell and put ---
+CASE 21 // cur(5,10) b1:r5:c3+2<3>  g(1,7)n[2,3,4*]
 
 === DISPLAY ===
-gfgm
-----+----1----+----2----+----3----+----4----+----5----+----6----+----7----+----8----+----9----+----0
-│名前⠀│⠀⠀│Age│City⠀⠀⠀⠀⠀⠀⠀│Age│City⠀⠀⠀⠀⠀⠀⠀│
-│----⠀│⠀⠀│---│----⠀⠀⠀⠀⠀⠀⠀│---│----⠀⠀⠀⠀⠀⠀⠀│
-│Alice│⠀⠀│23⠀│Tokyo⠀⠀⠀⠀⠀⠀│23⠀│Tokyo⠀⠀⠀⠀⠀⠀│
-┊Bob⠀⠀┊⠀⠀┊31⠀┊大阪↲⠀⠀⠀⠀⠀⠀┊31⠀┊大阪↲⠀⠀⠀⠀⠀⠀┊
-│⠀⠀⠀⠀⠀│⠀⠀│⠀⠀⠀│nipponbashi│⠀⠀⠀│nipponbashi│
-│Carol│⠀⠀│27⠀│名古屋⠀⠀⠀⠀⠀│27⠀│名古屋⠀⠀⠀⠀⠀│
-----+----1----+----2----+----3----+----4----+----5----+----6----+----7----+----8----+----9----+----0
-markdown
-
---- Java ---
+│1a│３a│ 2 a│
+┊1↲┊２⠀┊3↲⠀⠀┊
+│⠀⠀│⠀⠀⠀│b⇥⠀⠀│
+┊↲⠀┊⠀⠀⠀┊⇥c⠀⠀┊
+┊↲⠀┊⠀⠀⠀┊3↲⠀⠀┊
+┊↲⠀┊⠀⠀⠀┊b⇥⠀⠀┊
+│⠀⠀│⠀⠀⠀│⠀⠀⠀⠀│
 === MESSAGE ===
  
---- CASE 60: Java ---
+--- CASE 31: 2 column delete ---
+CASE 31 // cur(4,2) b1:r4:c1+1<⠀>  g(1,7)n[2*,3,4]
 
 === DISPLAY ===
-// |Key|Description|Example|
-// |name|||
-class Tir {
-  public static void main(String[] args){
-    System.out.println("Hello Tir");
-  }
-}
-
+│1a│３a│ 2 a│
+┊1↲┊２⠀┊3↲⠀⠀┊
+│⠀⠀│⠀⠀⠀│b⇥⠀⠀│
+┊⠀⠀┊⇥c⠀┊⠀⠀⠀⠀┊
+┊⠀⠀┊3↲⠀┊⠀⠀⠀⠀┊
+┊⠀⠀┊b⇥⠀┊⠀⠀⠀⠀┊
+│⠀⠀│⠀⠀⠀│⠀⠀⠀⠀│

--- a/tests/cases/textobj/vaic/out-expected.txt
+++ b/tests/cases/textobj/vaic/out-expected.txt
@@ -1,0 +1,66 @@
+--- CSV ---
+=== MESSAGE ===
+ 
+--- CASE 8: initial cached attrs ---
+CASE 8 // cur(1,5) b1:r1:c2+1<2>  g(1,7)n[2,3*,3]
+ 
+--- CASE 12: yank column and put ---
+block of 7 lines yanked
+CASE 12 // cur(1,12) b1:r1:c4+0<│>  g(1,7)n[2,3,3,3*]
+ 
+--- CASE 19: yank 2column and put ---
+CASE 19 // cur(7,3) b1:r7:c1+2<⠀>  g(1,7)n[2*,3,3,3]
+block of 7 lines yanked
+CASE 19 // cur(1,1) b1:r1:c1+0<│>  g(1,7)n[2*,3,2,3,3,3]
+ 
+--- CASE 28: repair disable ---
+[Tirenvi] repair:disable 
+tirenvi: Cannot select column: table is not aligned.
+
+=== DISPLAY ===
+│1a│2 a│1a│2 a│３a│2 a│
+┊1↲┊２⠀┊1↲┊２⠀┊3↲⠀┊２⠀┊
+│⠀⠀│⠀⠀⠀│⠀⠀│⠀⠀⠀│b⇥⠀│⠀⠀⠀│
+┊↲⠀┊⠀⠀⠀┊↲⠀┊⠀⠀⠀┊⇥c⠀┊⠀⠀⠀┊
+┊insert↲⠀┊⠀⠀⠀┊↲⠀┊⠀⠀⠀┊⠀⠀⠀┊⠀⠀⠀┊
+┊↲⠀┊⠀⠀⠀┊↲⠀┊⠀⠀⠀┊⠀⠀⠀┊⠀⠀⠀┊
+│⠀⠀│⠀⠀⠀│⠀⠀│⠀⠀⠀│⠀⠀⠀│⠀⠀⠀│
+--- GFM ---
+=== MESSAGE ===
+ 
+--- CASE 39: initial cached attrs ---
+CASE 39 // cur(1,1) b1:r1:c0+0<g>  p(1,2)* g(3,8)n[5,3,11] p(9,11)
+ 
+--- CASE 43: yank plain ---
+CASE 43 // cur(1,3) b1:r1:c0+0<g>  p(1,2)* g(3,8)n[5,3,11] p(9,11)
+ 
+--- CASE 50: yank 2column and put ---
+block of 6 lines yanked
+CASE 50 // cur(3,8) b2:r1:c2+1<│>  p(1,2) g(3,8)n[5,2*,3,11,3,11] p(9,11)
+
+=== DISPLAY ===
+gfgm
+----+----1----+----2----+----3----+----4----+----5----+----6----+----7----+----8----+----9----+----0
+│名前⠀│⠀⠀│Age│City⠀⠀⠀⠀⠀⠀⠀│Age│City⠀⠀⠀⠀⠀⠀⠀│
+│----⠀│⠀⠀│---│----⠀⠀⠀⠀⠀⠀⠀│---│----⠀⠀⠀⠀⠀⠀⠀│
+│Alice│⠀⠀│23⠀│Tokyo⠀⠀⠀⠀⠀⠀│23⠀│Tokyo⠀⠀⠀⠀⠀⠀│
+┊Bob⠀⠀┊⠀⠀┊31⠀┊大阪↲⠀⠀⠀⠀⠀⠀┊31⠀┊大阪↲⠀⠀⠀⠀⠀⠀┊
+│⠀⠀⠀⠀⠀│⠀⠀│⠀⠀⠀│nipponbashi│⠀⠀⠀│nipponbashi│
+│Carol│⠀⠀│27⠀│名古屋⠀⠀⠀⠀⠀│27⠀│名古屋⠀⠀⠀⠀⠀│
+----+----1----+----2----+----3----+----4----+----5----+----6----+----7----+----8----+----9----+----0
+markdown
+
+--- Java ---
+=== MESSAGE ===
+ 
+--- CASE 60: Java ---
+
+=== DISPLAY ===
+// |Key|Description|Example|
+// |name|||
+class Tir {
+  public static void main(String[] args){
+    System.out.println("Hello Tir");
+  }
+}
+

--- a/tests/cases/textobj/vaic/run.vim
+++ b/tests/cases/textobj/vaic/run.vim
@@ -9,57 +9,29 @@ CASE initial cached attrs
 	call At(1, 1, 2)
       lua print(Debug.layout())
 
-CASE yank column and put
+CASE dlete column and put
     	call feedkeys("vah", "x")
-    	normal! y
+    	normal! d
+		sleep 1m
     	normal! $h
     	normal! p
 			lua print(Debug.layout())
 call Snapshot({})
 
-CASE yank 2column and put
-	call At(1, 7, 1)
-	normal! l
+CASE yank cell and put
+	call At(1, 2, 3)
+    	call feedkeys("vih", "x")
+    	normal! y
+		sleep 1m
+	call At(1, 5, 3)
+    	normal! p
 			lua print(Debug.layout())
-    call feedkeys("v2ah", "x")
-		normal! y
-		normal! P
-			lua print(Debug.layout())
-
-CASE repair disable
-Tir repair disable
-	call At(1, 5, 1)
-		normal! hainsert
-    	call feedkeys("vah", "x")
-
 call Snapshot({})
 
-" ===== GFM =====
-edit $TIRENVI_ROOT/tests/data/simple.md
-
-CASE initial cached attrs
-	call At(1, 1, 1)
+CASE 2 column delete
+	call At(1, 5, 1)
+    	call feedkeys("v2ih", "x")
+    	normal! x
+		sleep 1m
 			lua print(Debug.layout())
-
-CASE yank plain
-    call feedkeys("vah", "x")
-		normal! y
-		normal! $h
-		normal! p
-			lua print(Debug.layout())
-
-CASE yank 2column and put
-	call At(2, 4, 2)
-    call feedkeys("v2ah", "x")
-		normal! ly
-		normal! p
-			lua print(Debug.layout())
-
-call Snapshot({ 'desc': 'GFM' })
-
-" ===== JAVA =====
-CASE Java
-	edit $TIRENVI_ROOT/tests/data/sample.java
-    call feedkeys("vah", "x")
-
-call Snapshot({ 'desc': 'Java' })
+call Snapshot({})

--- a/tests/cases/textobj/vaic/run.vim
+++ b/tests/cases/textobj/vaic/run.vim
@@ -1,0 +1,65 @@
+source $TIRENVI_ROOT/tests/common.vim
+
+lua require("tirenvi").setup({ textobj = { cell = "h" }, })
+
+" ===== CSV =====
+edit $TIRENVI_ROOT/tests/data/simple.csv
+
+CASE initial cached attrs
+	call At(1, 1, 2)
+      lua print(Debug.layout())
+
+CASE yank column and put
+    	call feedkeys("vah", "x")
+    	normal! y
+    	normal! $h
+    	normal! p
+			lua print(Debug.layout())
+call Snapshot({})
+
+CASE yank 2column and put
+	call At(1, 7, 1)
+	normal! l
+			lua print(Debug.layout())
+    call feedkeys("v2ah", "x")
+		normal! y
+		normal! P
+			lua print(Debug.layout())
+
+CASE repair disable
+Tir repair disable
+	call At(1, 5, 1)
+		normal! hainsert
+    	call feedkeys("vah", "x")
+
+call Snapshot({})
+
+" ===== GFM =====
+edit $TIRENVI_ROOT/tests/data/simple.md
+
+CASE initial cached attrs
+	call At(1, 1, 1)
+			lua print(Debug.layout())
+
+CASE yank plain
+    call feedkeys("vah", "x")
+		normal! y
+		normal! $h
+		normal! p
+			lua print(Debug.layout())
+
+CASE yank 2column and put
+	call At(2, 4, 2)
+    call feedkeys("v2ah", "x")
+		normal! ly
+		normal! p
+			lua print(Debug.layout())
+
+call Snapshot({ 'desc': 'GFM' })
+
+" ===== JAVA =====
+CASE Java
+	edit $TIRENVI_ROOT/tests/data/sample.java
+    call feedkeys("vah", "x")
+
+call Snapshot({ 'desc': 'Java' })


### PR DESCRIPTION
Add cell text objects `vac` and `vic`.

- `vac`: select a cell including the left border
- `vic`: select cell content without the left border
- Support multi-line selection for wrapped cells
- Refactor visual block setup to share column and cell selection logic