### PR TITLE
fix: use parser flag to detect embedded mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ require("tirenvi").setup({
     csv = { executable = "tir-csv", required_version = "0.1.4" },
     tsv = { executable = "tir-csv", options = { "--delimiter", "\t" }, required_version = "0.1.4" },
     markdown = { executable = "tir-gfm-lite", allow_plain = true, required_version = "0.1.6" },
-    ["*"] = { executable = "tir-embedded", allow_plain = true },
+    ["*"] = { executable = "tir-embedded", allow_plain = true, embedded = true },
     pukiwiki = { executable = "tir-pukiwiki", allow_plain = true, required_version = "0.1.1" },
   }
 })

--- a/lua/tirenvi/config.lua
+++ b/lua/tirenvi/config.lua
@@ -41,6 +41,7 @@ local defaults = {
 		["*"] = {
 			executable = "tir-embedded",
 			allow_plain = true,
+			embedded = true,
 		},
 	},
 	textobj = {

--- a/lua/tirenvi/parser/parser.lua
+++ b/lua/tirenvi/parser/parser.lua
@@ -3,6 +3,7 @@ local fn = vim.fn -- Neovim
 local config = require("tirenvi.config") -- Root
 
 local errors = require("tirenvi.util.errors") -- Util
+local util = require("tirenvi.util.util")
 local log = require("tirenvi.util.log")
 
 -- =============================================================================
@@ -12,6 +13,7 @@ local log = require("tirenvi.util.log")
 ---@field options? string[]             Command-line arguments passed to the parser
 ---@field required_version? string      Parser required version "major.minor.patch"
 ---@field allow_plain? boolean          Whether plain blocks are allowed (GFM). If false, only a single table is permitted.
+---@field embedded? boolean          	parser for embedded
 ---@field _required_version_int? integer required version
 ---@field _installed_version? string    installed version
 ---@field _err_code? string             error code
@@ -192,7 +194,7 @@ end
 ---@param self Parser
 ---@return boolean
 function M.is_embedded(self)
-	return self.executable == "tir-embedded"
+	return self.embedded == true
 end
 
 return M


### PR DESCRIPTION
Fix embedded parser detection by using an explicit `embedded` flag on the parser.

The previous implementation determined whether a parser was embedded from
the executable path. This failed when `tir-embedded` was specified using a
relative path.

The parser now carries the `embedded` flag, and `Parser.is_embedded()` checks
that flag directly.